### PR TITLE
fix: use this.stateService.lastBlockHeight in order to provide defaul…

### DIFF
--- a/frontend/src/app/oe/services/state.service.ts
+++ b/frontend/src/app/oe/services/state.service.ts
@@ -7,6 +7,7 @@ import { WebsocketService } from 'src/app/services/websocket.service';
 
 import { WebsocketResponse, IBackendInfo } from '../../interfaces/websocket.interface';
 import { OpEnergyWebsocketResponse } from '../interfaces/websocket.interface';
+import { BlockExtended } from 'src/app/interfaces/node-api.interface';
 import { take, switchMap} from 'rxjs/operators';
 
 
@@ -21,6 +22,8 @@ export class OeStateService {
   timeStrikes$ = new ReplaySubject<TimeStrike>(1);
   timeSlowFastGuesses$ = new ReplaySubject<SlowFastGuess>(1);
   timeSlowFastGuessesOutcome$ = new ReplaySubject<SlowFastGuessOutcome>(1);
+  latestReceivedBlock$ = new ReplaySubject<BlockExtended>(1); // this object will only contain the last block received from the backend. This block can be considered as the current tip
+  latestReceivedBlockHeight = -1; // plain  block height of the latest recevied block. Need this value to handle the case when backend sends newly found block
 
 
   private apiBaseUrl: string; // base URL is protocol, hostname, and port
@@ -43,6 +46,17 @@ export class OeStateService {
 
   // callback which will be called by websocket service
   handleWebsocketResponse( websocketService: WebsocketService, response: OpEnergyWebsocketResponse) {
+
+    if (response.blocks && response.blocks.length > 0) { // we need to know the last block received from the backend. Mempool's behavior is to walk through all the received blocks one by one, but this means, that stateService.lastestBlockHeight may not be current tip until stateService won't receive the last block from websocket service. The difference here is that we store the last block asap and this means, that this block is always the currenttip
+      const block = response.blocks[response.blocks.length - 1];
+      this.latestReceivedBlock$.next( block);
+    }
+    if (response.block && response.block.height > this.latestReceivedBlockHeight) {
+      this.latestReceivedBlockHeight = response.block.height;
+      this.latestReceivedBlock$.next(response.block);
+    }
+
+
     if( response.declinedAccountSecret) {
       websocketService.want(['generatedaccounttoken']);
     }


### PR DESCRIPTION
Currently, blockspans-home component is trying to guess tip by piping list of the last discovered blocks and using each's height as a tip. This results a content update behavior while pipe is walking through the bottom of the list until the top...

This PR is using stateService.latestBlockHeight instead and thus has no content update behavior