### PR TITLE
chore:

### DIFF
--- a/frontend/src/app/oe/components/base-box/base-box.component.html
+++ b/frontend/src/app/oe/components/base-box/base-box.component.html
@@ -21,7 +21,7 @@
       <div class="span-block">{{ nbdr || '?' }}</div>
       <div class="from-block">{{ fromTime * 1000 | date:'yyyy-MM-dd HH:mm' }}</div>
     </div>
+    <div class="tank-box--footer" [ngStyle]="{'background-color': this.color}">utc time</div>
   </ng-container>
-  <div class="tank-box--footer" [ngStyle]="{'background-color': this.color}">utc time</div>
   <div class="tank-box--footer" [ngStyle]="{'background-color': this.color}">{{ footerText }}</div>
 </a>

--- a/frontend/src/app/oe/components/base-box/base-box.component.scss
+++ b/frontend/src/app/oe/components/base-box/base-box.component.scss
@@ -49,7 +49,7 @@
       color: black;
       font-weight: bold;
       position: absolute;
-      width: 50%;
+      width: 80%;
       height: 30%;
       background-color: orange;
       top: 50%;

--- a/frontend/src/app/oe/components/base-box/base-box.component.ts
+++ b/frontend/src/app/oe/components/base-box/base-box.component.ts
@@ -37,7 +37,7 @@ export class BaseBoxComponent implements OnInit, OnDestroy {
   }
 
   get nbdr() {
-    return this.span ? (600 * this.span / (this.toTime - this.fromTime)).toFixed(2) : '???'
+    return this.span ? (600 * 100 * this.span / (this.toTime - this.fromTime)).toFixed(2) : '???'
   }
 
   constructor(

--- a/frontend/src/app/oe/components/blockspans-home/blockspans-home.component.ts
+++ b/frontend/src/app/oe/components/blockspans-home/blockspans-home.component.ts
@@ -7,7 +7,7 @@ import { StateService } from 'src/app/services/state.service';
 import { ActivatedRoute, ParamMap, Router } from '@angular/router';
 import { specialBlocks } from 'src/app/app.constants';
 import { ElectrsApiService } from 'src/app/services/electrs-api.service';
-import { switchMap, skip, map } from 'rxjs/operators';
+import { switchMap, map, take } from 'rxjs/operators';
 import { RelativeUrlPipe } from 'src/app/shared/pipes/relative-url/relative-url.pipe';
 import { OpEnergyApiService } from 'src/app/oe/services/op-energy.service';
 import { TimeStrike } from 'src/app/oe/interfaces/op-energy.interface';
@@ -27,7 +27,7 @@ export class BlockspansHomeComponent implements OnInit, OnDestroy {
   network = '';
   allBlocks: PastBlock[] = [];
   pastBlocks: PastBlock[] = [];
-  indexArray = [1, 3, 5, 7, 9, 11];
+  indexArray = [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21];
   lastPastBlock: PastBlock;
   emptyBlocks: Block[] = this.mountEmptyBlocks();
   markHeight: number;
@@ -147,7 +147,9 @@ export class BlockspansHomeComponent implements OnInit, OnDestroy {
           switchMap(hash => this.opEnergyApiService.$getBlock(hash))
         )
       )
-    ).subscribe((blocks: any[]) => {
+    )
+    .pipe(take(1))
+    .subscribe((blocks: any[]) => {
       this.pastBlocks = blocks;
       this.cd.markForCheck();
       console.log('pastBlocks...', this.pastBlocks)

--- a/frontend/src/app/oe/components/energy/energy.component.html
+++ b/frontend/src/app/oe/components/energy/energy.component.html
@@ -1,4 +1,4 @@
 <div class="energy-container">
   <app-blockspan *ngIf="fromBlock && toBlock" [fromBlock]="fromBlock" [toBlock]="toBlock"></app-blockspan>
-  <app-base-box footerText="Energy" [totalIconCount]="totalIconCount" [span]="span" [fromTime]="fromBlock.mediantime" [toTime]="toBlock.mediantime" [isUnknown]="!timeDiff" [isDetailed]="isDetailed" [link]="energyDetailLink()"></app-base-box>
+  <app-base-box footerText="Energy (nbdr)" [totalIconCount]="totalIconCount" [span]="span" [fromTime]="fromBlock.mediantime" [toTime]="toBlock.mediantime" [isUnknown]="!timeDiff" [isDetailed]="isDetailed" [link]="energyDetailLink()"></app-base-box>
 </div>

--- a/frontend/src/app/oe/components/oe-master-page/oe-master-page.component.html
+++ b/frontend/src/app/oe/components/oe-master-page/oe-master-page.component.html
@@ -63,7 +63,7 @@
     </ul>
     <app-search-form class="search-form-container" location="top" (searchTriggered)="collapse()"></app-search-form>
   </div>
-  <div class="navbar-nav" *ngIf="( this.opEnergyStateService.$showAccountURLWarning | async) === true" >
+  <div class="navbar-nav account-token-popup" *ngIf="( this.opEnergyStateService.$showAccountURLWarning | async) === true" >
     <div>
       WARNING: store your secret account URL<app-clipboard [text]="(this.baseUrl + this.basePath) + '/account/' + (this.opEnergyStateService.$accountSecret | async)"></app-clipboard> and use it to access op-energy later
     </div>

--- a/frontend/src/app/oe/components/oe-master-page/oe-master-page.component.scss
+++ b/frontend/src/app/oe/components/oe-master-page/oe-master-page.component.scss
@@ -60,6 +60,14 @@ li.nav-item {
       font-size: 1em;
     }
   }
+
+  &.account-token-popup {
+    bottom: 0px;
+
+    @media (max-width: 420px) {
+      bottom: 56px;
+    }
+  }
 }
 
 

--- a/frontend/src/app/services/state.service.ts
+++ b/frontend/src/app/services/state.service.ts
@@ -49,7 +49,7 @@ const defaultEnv: Env = {
   'BISQ_ENABLED': false,
   'BISQ_SEPARATE_BACKEND': false,
   'ITEMS_PER_PAGE': 10,
-  'KEEP_BLOCKS_AMOUNT': 8,
+  'KEEP_BLOCKS_AMOUNT': 22,
   'OFFICIAL_MEMPOOL_SPACE': false,
   'NGINX_PROTOCOL': 'http',
   'NGINX_HOSTNAME': '127.0.0.1',


### PR DESCRIPTION
- remove the "utc time" , energy(nbdr)
- numbers overflowing orange square, make it wider. corrected the nbdr value
- account token popup covers the menu, when viewing on phone
- number updated / jumped around several times - This is because a new block is being added periodically. So disable websocket update
- show 11 blockspans

<!--
Please do not open pull requests for translations.

All translations work is done on Transifex:
https://www.transifex.com/mempool/mempool
-->
