### PR TITLE
feat: restart op-energy service

### DIFF
--- a/nix/module-backend.nix
+++ b/nix/module-backend.nix
@@ -153,6 +153,9 @@ in
           ];
         serviceConfig = {
           Type = "simple";
+          Restart = "always"; # we want to keep service always running, especially, now development instance is relying on ssh tunnel which can restart as well leading to op-energy restart as well
+          StartLimitIntervalSec = 0;
+          StartLimitBurst = 0;
         };
         path = with pkgs; [
           nodejs


### PR DESCRIPTION
Currently, op-energy service won't be restarted in case of fail. We had no such issues in the past, but as now we are going to provide an access to remote mainnet node for development op-energy instance and now such remote access can be inaccessable for some time due to network issues. Other than that, there is a case when we can just restart mainnet node, which will lead to op-energy instance. 

This PR provides an ability to service to be automatically restarted after fail