### PR TITLE
321 blockspan should use our source of data

### DIFF
--- a/backend/src/api/websocket-handler.ts
+++ b/backend/src/api/websocket-handler.ts
@@ -215,6 +215,7 @@ class WebsocketHandler {
     if (!_blocks) {
       _blocks = blocks.getBlocks().slice(-config.MEMPOOL.INITIAL_BLOCKS_AMOUNT);
     }
+    const newExtraInitProperties = opEnergyWebSocket.getInitData( this.extraInitProperties); // op-energy hook
     return {
       'mempoolInfo': memPool.getMempoolInfo(),
       'vBytesPerSecond': memPool.getVBytesPerSecond(),
@@ -224,10 +225,9 @@ class WebsocketHandler {
       'transactions': memPool.getLatestTransactions(),
       'backendInfo': backendInfo.getBackendInfo(),
       'loadingIndicators': loadingIndicators.getLoadingIndicators(),
-      'lastDifficultyEpochEndBlocks': oeBlocks.getDifficultyEpochEndBlocks(),
       'da': difficultyAdjustment.getDifficultyAdjustment(),
       'fees': feeApi.getRecommendedFee(),
-      ...this.extraInitProperties
+      ...newExtraInitProperties
     };
   }
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -133,7 +133,7 @@ class Server {
 
     fiatConversion.startService();
 
-    this.setUpHttpApiRoutes();
+    await this.setUpHttpApiRoutes();
     this.runMainUpdateLoop();
 
     if (config.BISQ.ENABLED) {
@@ -229,9 +229,9 @@ class Server {
     }
   }
 
-  setUpHttpApiRoutes() {
+  async setUpHttpApiRoutes() {
     bitcoinRoutes.initRoutes(this.app);
-    opEnergyIndex.setUpHttpApiRoutes(this.app);
+    await opEnergyIndex.setUpHttpApiRoutes(this.app);
     if (config.STATISTICS.ENABLED && config.DATABASE.ENABLED) {
       statisticsRoutes.initRoutes(this.app);
     }

--- a/backend/src/oe/api/websocket.ts
+++ b/backend/src/oe/api/websocket.ts
@@ -137,6 +137,37 @@ class OpEnergyWebsocket {
     });
   }
 
+  /**
+   * O(n)
+   * this procedure sends given message to all the connected websocket clients
+   */
+  public sendToAllClients( msg: any) {
+    if( !OpEnergyWebsocket.wss) {
+      return;
+    }
+    OpEnergyWebsocket.wss.clients.forEach((client) => {
+      if (client.readyState === WebSocket.OPEN) {
+        try { // don't throw an error in case if any client's stream will be terminated
+          client.send(JSON.stringify( msg));
+        } catch( error) {
+          // we don't need to handle it as it is expected that client will receive update within reconnection procedure
+        }
+      }
+    });
+  }
+
+  /**
+   * O(n) (where n - is initialSet's number of keys)
+   * returns initial set including op-energy related data
+   */
+  public getInitData( initialSet: any): any {
+    const newestConfirmedBlock = opEnergyApiService.getLatestConfirmedBlockHeader(); // get block header from cache
+    return {
+      'newest-confirmed-block': newestConfirmedBlock,
+      ...initialSet
+    };
+  }
+
 }
 
 export default new OpEnergyWebsocket();

--- a/backend/src/oe/api/websocket.ts
+++ b/backend/src/oe/api/websocket.ts
@@ -163,7 +163,7 @@ class OpEnergyWebsocket {
   public getInitData( initialSet: any): any {
     const newestConfirmedBlock = opEnergyApiService.getLatestConfirmedBlockHeader(); // get block header from cache
     return {
-      'newest-confirmed-block': newestConfirmedBlock,
+      'oe-newest-confirmed-block': newestConfirmedBlock,
       ...initialSet
     };
   }

--- a/backend/src/oe/service/op-block-header.service.ts
+++ b/backend/src/oe/service/op-block-header.service.ts
@@ -51,7 +51,7 @@ export class OpBlockHeaderService {
    * returns BlockHeader of the last confirmed block
    */
   public async $syncOlderBlockHeader(UUID: string, currentTip?: number): Promise<BlockHeader> {
-    var latestConfirmedBlockHeight : ConfirmedBlockHeight | undefined = undefined;
+    let latestConfirmedBlockHeight : ConfirmedBlockHeight | undefined = undefined;
     try {
       logger.debug('Syncing older block headers');
 

--- a/frontend/src/app/oe/services/state.service.ts
+++ b/frontend/src/app/oe/services/state.service.ts
@@ -47,13 +47,10 @@ export class OeStateService {
   // callback which will be called by websocket service
   handleWebsocketResponse( websocketService: WebsocketService, response: OpEnergyWebsocketResponse) {
 
-    if (response.blocks && response.blocks.length > 0) { // we need to know the last block received from the backend. Mempool's behavior is to walk through all the received blocks one by one, but this means, that stateService.lastestBlockHeight may not be current tip until stateService won't receive the last block from websocket service. The difference here is that we store the last block asap and this means, that this block is always the currenttip
-      const block = response.blocks[response.blocks.length - 1];
+    if( response['oe-newest-confirmed-block'] && response['oe-newest-confirmed-block'].height !== undefined) {
+      this.latestReceivedBlockHeight = response['oe-newest-confirmed-block'].height;
+      const block = response['oe-newest-confirmed-block'];
       this.latestReceivedBlock$.next( block);
-    }
-    if (response.block && response.block.height > this.latestReceivedBlockHeight) {
-      this.latestReceivedBlockHeight = response.block.height;
-      this.latestReceivedBlock$.next(response.block);
     }
 
 


### PR DESCRIPTION
This PR introduces new Websocket notification from backend: `oe-newest-confirmed-block` : `<BlockHeader>`. 
Frontend's state service in it's turn handles this notification by storing block header in the `latestReceivedBlock$` ReplaySubject instance and by storing appropriate block height in the `latestReceivedBlockHeight` variable.

This allows OpEnergy-part of frontend services to use data provided by OpEnergy part of backend