### PR TITLE
feat: refactor GET /api/v1/oe/block/ to use our 'blocks' table

### DIFF
--- a/backend/src/oe/api/op-energy.service.ts
+++ b/backend/src/oe/api/op-energy.service.ts
@@ -496,9 +496,11 @@ export class OpEnergyApiService {
     }
   }
 
-  public async $getBlockByHash( hash: BlockHash): Promise<IEsploraApi.Block> {
-    // using our own block cache goes here
-    return await bitcoinApi.$getBlock(hash.value);
+  /**
+   * just a wrapper over OpBlockHeaderService.$getBlockHeaderByHash
+   */
+  public async $getBlockByHash( UUID: string, hash: BlockHash): Promise<BlockHeader> {
+    return await opBlockHeaderService.$getBlockHeaderByHash(UUID, hash);
   }
 
   public $getBlockSpanList(UUID: string, startBlockHeight: number, span: number, numberOfSpan: number): BlockSpan[] {

--- a/backend/src/oe/api/routes.ts
+++ b/backend/src/oe/api/routes.ts
@@ -236,7 +236,7 @@ class OpEnergyRoutes {
     try {
       logger.info( `${UUID}: PROFILE: start: $getBlockByHash`);
       const { hash } = req.params;
-      const result = await opEnergyApiService.$getBlockByHash(opEnergyApiService.verifyBlockHash(hash));
+      const result = await opEnergyApiService.$getBlockByHash(UUID, opEnergyApiService.verifyBlockHash(hash));
       res.json(result);
     } catch(e) {
       logger.err( `ERROR: ${UUID}: OpEnergyApiService.$getBlockByHash: ${e instanceof Error ? e.message: e}`);

--- a/backend/src/oe/service/op-block-header.service.ts
+++ b/backend/src/oe/service/op-block-header.service.ts
@@ -1,4 +1,4 @@
-import { BlockHeader, BlockHeight, ConfirmedBlockHeight } from './../api/interfaces/op-energy.interface';
+import { BlockHeader, BlockHeight, ConfirmedBlockHeight, BlockHash } from './../api/interfaces/op-energy.interface';
 import Bluebird = require('bluebird');
 import bitcoinApi from '../../api/bitcoin/bitcoin-api-factory';
 import config from '../../config';
@@ -134,6 +134,13 @@ export class OpBlockHeaderService {
       logger.err(`Something went wrong while fetching block header range.` + error);
       throw error;
     }
+  }
+
+  /**
+   * see OpBlockHeaderRepository.$getBlockHeaderByHash for reference as this function is just a wrapper over it
+   */
+  public async $getBlockHeaderByHash( UUID: string, blockHash: BlockHash): Promise<BlockHeader> {
+    return await opBlockHeaderRepository.$getBlockHeaderByHash( UUID, blockHash);
   }
 
   public verifyConfirmedBlockHeight(blockHeight: number, currentTip: BlockHeight): ConfirmedBlockHeight {


### PR DESCRIPTION
/api/v1/oe/block API call should use our `blocks` table