### PR TITLE
337 provide similar api call to apiv1oeblock but with height instead of hash as parameter

### DIFF
--- a/backend/src/oe/api/op-energy.service.ts
+++ b/backend/src/oe/api/op-energy.service.ts
@@ -503,6 +503,15 @@ export class OpEnergyApiService {
     return await opBlockHeaderService.$getBlockHeaderByHash(UUID, hash);
   }
 
+  /**
+   * just a wrapper over OpBlockHeaderService.$getBlockHeader
+   */
+  public async $getBlockByHeight( UUID: string, height: BlockHeight): Promise<BlockHeader> {
+    const currentTip = await bitcoinApi.$getBlockHeightTip();
+    const confirmedHeight = opBlockHeaderService.verifyConfirmedBlockHeight( height.value, { value: currentTip} );
+    return await opBlockHeaderService.$getBlockHeader(UUID, confirmedHeight);
+  }
+
   public $getBlockSpanList(UUID: string, startBlockHeight: number, span: number, numberOfSpan: number): BlockSpan[] {
     try {
       const blockSpanList = [] as BlockSpan[];

--- a/backend/src/oe/api/routes.ts
+++ b/backend/src/oe/api/routes.ts
@@ -29,6 +29,7 @@ class OpEnergyRoutes {
       .post(config.MEMPOOL.API_URL_PREFIX + 'user/displayname', this.$postUserDisplayName)
       .get(config.MEMPOOL.API_URL_PREFIX + 'statistics/:blockheight/:span', this.$getBlockSpanStatistics)
       .get(config.MEMPOOL.API_URL_PREFIX + 'oe/block/:hash', this.$getBlockByHash)
+      .get(config.MEMPOOL.API_URL_PREFIX + 'oe/blockbyheight/:height', this.$getBlockByHeight)
       .get(config.MEMPOOL.API_URL_PREFIX + 'oe/blockspanlist/:startBlockHeight/:span/:numberOfSpan', this.$getBlockSpanList)
   }
 
@@ -243,6 +244,20 @@ class OpEnergyRoutes {
       res.status(404).send(`${UUID}: ${e instanceof Error? e.message : e}`);
     }
     logger.info( `${UUID}: PROFILE: end: $getBlockByHash`);
+  }
+
+  private async $getBlockByHeight(req: Request, res: Response) {
+    const UUID = await opEnergyApiService.$generateRandomHash();
+    try {
+      logger.info( `${UUID}: PROFILE: start: $getBlockByHeight`);
+      const { height } = req.params;
+      const result = await opEnergyApiService.$getBlockByHeight(UUID, opEnergyApiService.verifyBlockHeight(parseInt(height)));
+      res.json(result);
+    } catch(e) {
+      logger.err( `ERROR: ${UUID}: OpEnergyApiService.$getBlockByHeight: ${e instanceof Error ? e.message: e}`);
+      res.status(404).send(`${UUID}: ${e instanceof Error? e.message : e}`);
+    }
+    logger.info( `${UUID}: PROFILE: end: $getBlockByHeight`);
   }
 
   private async $getBlockSpanList(req: Request, res: Response) {

--- a/backend/src/oe/api/routes.ts
+++ b/backend/src/oe/api/routes.ts
@@ -250,8 +250,12 @@ class OpEnergyRoutes {
     const UUID = await opEnergyApiService.$generateRandomHash();
     try {
       logger.info( `${UUID}: PROFILE: start: $getBlockByHeight`);
-      const { height } = req.params;
-      const result = await opEnergyApiService.$getBlockByHeight(UUID, opEnergyApiService.verifyBlockHeight(parseInt(height)));
+      const { heightS } = req.params;
+      const height = parseInt( heightS);
+      if( isNaN( height) ) {
+        throw new Error( 'height is not a number');
+      }
+      const result = await opEnergyApiService.$getBlockByHeight(UUID, opEnergyApiService.verifyBlockHeight(height));
       res.json(result);
     } catch(e) {
       logger.err( `ERROR: ${UUID}: OpEnergyApiService.$getBlockByHeight: ${e instanceof Error ? e.message: e}`);

--- a/backend/src/oe/api/swagger.json
+++ b/backend/src/oe/api/swagger.json
@@ -340,9 +340,11 @@
         "parameters": [
           {
             "in": "path",
+            "maximum": 9223372036854776000,
+            "minimum": 0,
             "name": "blockheight",
             "required": true,
-            "type": "string"
+            "type": "number"
           },
           {
             "in": "path",
@@ -387,6 +389,35 @@
           },
           "400": {
             "description": "Invalid `hash`"
+          }
+        }
+      }
+    },
+    "/api/v1/oe/blockbyheight/{height}": {
+      "get": {
+        "description": "Returns block's header by a given block hash, including chainwork, that is missing from mempool's blocks' headers cache",
+        "produces": [
+          "application/json;charset=utf-8"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "maximum": 9223372036854776000,
+            "minimum": 0,
+            "name": "height",
+            "required": true,
+            "type": "number"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/Block"
+            }
+          },
+          "400": {
+            "description": "Invalid `height`"
           }
         }
       }

--- a/backend/src/oe/api/swagger.json
+++ b/backend/src/oe/api/swagger.json
@@ -395,7 +395,7 @@
     },
     "/api/v1/oe/blockbyheight/{height}": {
       "get": {
-        "description": "Returns block's header by a given block hash, including chainwork, that is missing from mempool's blocks' headers cache",
+        "description": "Returns block's header by a given block height",
         "produces": [
           "application/json;charset=utf-8"
         ],

--- a/frontend/src/app/oe/components/blockspans-home/blockspans-home.component.ts
+++ b/frontend/src/app/oe/components/blockspans-home/blockspans-home.component.ts
@@ -154,9 +154,7 @@ export class BlockspansHomeComponent implements OnInit, OnDestroy {
     this.pastBlocks = [];
     forkJoin(
       blockNumbers.map(
-        blockNo => this.electrsApiService.getBlockHashFromHeight$(blockNo).pipe(
-          switchMap(hash => this.opEnergyApiService.$getBlock(hash))
-        )
+        blockNo => this.opEnergyApiService.$getBlockByHeight(blockNo)
       )
     )
     .pipe(take(1))

--- a/frontend/src/app/oe/interfaces/op-energy.interface.ts
+++ b/frontend/src/app/oe/interfaces/op-energy.interface.ts
@@ -62,3 +62,17 @@ export interface BlockSpan {
   startBlockHeight: number,
   endBlockHeight: number,
 }
+
+export interface BlockHeader {
+  height: number;
+  version: number;
+  current_block_hash: string;
+  previous_block_hash: string;
+  merkle_root: string;
+  timestamp: number;
+  difficulty: number;
+  nonce: number;
+  reward: number;
+  chainwork: string;
+  mediantime: number;
+}

--- a/frontend/src/app/oe/services/op-energy.service.ts
+++ b/frontend/src/app/oe/services/op-energy.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { ReplaySubject, BehaviorSubject, Subject, fromEvent, Observable } from 'rxjs';
 import { HttpParams, HttpClient } from '@angular/common/http';
-import { TimeStrike, SlowFastGuess, SlowFastGuessOutcome, TimeStrikesHistory, SlowFastResult, EnergyNbdrStatistics, BlockSpan } from '../interfaces/op-energy.interface';
+import { TimeStrike, SlowFastGuess, SlowFastGuessOutcome, TimeStrikesHistory, SlowFastResult, EnergyNbdrStatistics, BlockSpan, BlockHeader } from '../interfaces/op-energy.interface';
 import { StateService } from '../../services/state.service';
 import { WebsocketService } from 'src/app/services/websocket.service';
 import { Block } from 'src/app/interfaces/electrs.interface';
@@ -152,6 +152,10 @@ export class OpEnergyApiService {
 
   $getBlock( hash: string): Observable<Block> {
     return this.httpClient.get<Block>(this.apiBaseUrl + this.apiBasePath + '/api/oe/block/' + hash);
+  }
+
+  $getBlockByHeight( height: number): Observable<BlockHeader> {
+    return this.httpClient.get<BlockHeader>(this.apiBaseUrl + this.apiBasePath + '/api/oe/blockbyheight/' + height);
   }
 
   $getNbdrStatistics(blockHeight: number, span: number): Observable<EnergyNbdrStatistics> {


### PR DESCRIPTION
This PR addresses issue https://github.com/dambaev/op-energy/issues/337 :+1: 

the common way of getting block's  metadata is to get it by hash, but hash is 64-byte string, which is not ordered and not indexed. Querying metadata by block's height is much faster as height is the integer, which is both ordered and indexed.

This PR introduces API call /api/v1/oe/blockbyheight/{height} and adjusts blockspans-home to use this call