### PR TITLE
Bug fix: block with height 0 not in database and hashrate endpoint not found

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -234,9 +234,9 @@ class Server {
     if (config.STATISTICS.ENABLED && config.DATABASE.ENABLED) {
       statisticsRoutes.initRoutes(this.app);
     }
-    if (Common.indexingEnabled()) {
-      miningRoutes.initRoutes(this.app);
-    }
+    // if (Common.indexingEnabled()) {
+    miningRoutes.initRoutes(this.app);
+    // }
     if (config.BISQ.ENABLED) {
       bisqRoutes.initRoutes(this.app);
     }


### PR DESCRIPTION
This PR consists of fixes for:
1. Block with height 0 not present in the database inside the blocks table
2. `mining/hashrate/:interval` endpoint gives a 404 - Not found error