### PR TITLE
356 backend should serve profiling metrics

### DIFF
--- a/op-energy-backend/app/Main.hs
+++ b/op-energy-backend/app/Main.hs
@@ -1,6 +1,7 @@
 {-- | This module is backend's entrypoint
  -}
 {-# LANGUAGE TemplateHaskell            #-}
+{-# LANGUAGE FlexibleInstances          #-}
 module Main where
 
 import           Network.Wai.Handler.Warp
@@ -14,7 +15,8 @@ import           Control.Monad (forM, mapM)
 import           Data.List as L
 import           Control.Exception as E
 import           Control.Monad.IO.Class( liftIO)
-import           Control.Monad.Logger (runStdoutLoggingT, logInfo, askLoggerIO)
+import           Control.Monad.Logger (runStdoutLoggingT, logInfo, askLoggerIO, LoggingT)
+import           Prometheus(MonadMonitor(..))
 
 import           Data.OpEnergy.API
 import           OpEnergy.Server
@@ -23,6 +25,8 @@ import           OpEnergy.Server.V1.Config
 import           OpEnergy.Server.V1.Metrics
 import           OpEnergy.Server.V1.Class (State(..), defaultState, runAppT, runLogging)
 
+
+instance MonadMonitor (LoggingT IO)
 
 -- | entry point
 main :: IO ()

--- a/op-energy-backend/app/Main.hs
+++ b/op-energy-backend/app/Main.hs
@@ -8,6 +8,7 @@ import           Data.Proxy
 import qualified Data.Text.IO as Text
 import           Servant
 import           Control.Concurrent.Async
+import qualified Control.Concurrent.MVar as MVar
 import           System.IO
 import           Control.Monad (forM, mapM)
 import           Data.List as L
@@ -19,13 +20,18 @@ import           Data.OpEnergy.API
 import           OpEnergy.Server
 import           OpEnergy.Server.V1
 import           OpEnergy.Server.V1.Config
+import           OpEnergy.Server.V1.Metrics
 import           OpEnergy.Server.V1.Class (State(..), defaultState, runAppT, runLogging)
 
 
 -- | entry point
 main :: IO ()
 main = runStdoutLoggingT $ do
-  state <- OpEnergy.Server.initState
+  config <- liftIO $ OpEnergy.Server.V1.Config.getConfigFromEnvironment
+  metricsV <- liftIO $ MVar.newEmptyMVar -- prometheus's thread will put value into this variable
+  prometheusA <- liftIO $ asyncBound $ OpEnergy.Server.V1.Metrics.runMetricsServer config metricsV
+  metrics <- liftIO $ MVar.readMVar metricsV
+  state <- OpEnergy.Server.initState config metrics
   runAppT state $ runLogging $ $(logInfo) "bootstrap tasks"
   OpEnergy.Server.bootstrapTasks state
   -- now spawn worker threads
@@ -38,5 +44,6 @@ main = runStdoutLoggingT $ do
   liftIO $ waitAnyCancel $ -- waits for any of threads to shutdown in order to shutdown the rest
     [ serverA
     , schedulerA
+    , prometheusA
     ]
   return ()

--- a/op-energy-backend/derivation.nix
+++ b/op-energy-backend/derivation.nix
@@ -16,6 +16,7 @@
 , op-energy-api
 , stm, stm-chans
 , transformers
+, prometheus
 , GIT_COMMIT_HASH
 , ...
 }:
@@ -43,6 +44,7 @@ mkDerivation {
     transformers
     warp
     monad-logger
+    prometheus
   ];
   preBuild = ''
     sed -i 's/GIT_COMMIT_HASH/${GIT_COMMIT_HASH}/' src/OpEnergy/Server/GitCommitHash.hs

--- a/op-energy-backend/derivation.nix
+++ b/op-energy-backend/derivation.nix
@@ -16,7 +16,10 @@
 , op-energy-api
 , stm, stm-chans
 , transformers
-, prometheus
+, prometheus-client
+, prometheus-metrics-ghc
+, prometheus-proc
+, wai-middleware-prometheus
 , GIT_COMMIT_HASH
 , ...
 }:
@@ -44,7 +47,10 @@ mkDerivation {
     transformers
     warp
     monad-logger
-    prometheus
+    prometheus-client
+    prometheus-metrics-ghc
+    prometheus-proc
+    wai-middleware-prometheus
   ];
   preBuild = ''
     sed -i 's/GIT_COMMIT_HASH/${GIT_COMMIT_HASH}/' src/OpEnergy/Server/GitCommitHash.hs

--- a/op-energy-backend/op-energy-backend.cabal
+++ b/op-energy-backend/op-energy-backend.cabal
@@ -88,6 +88,7 @@ library
                     , warp
                     , monad-logger
                     , prometheus
+                    , clock
     ghc-options:    -O2 -Wall -Werror -Wno-unticked-promoted-constructors -fno-warn-name-shadowing -Wno-orphans
     extensions:       OverloadedStrings
                     , ScopedTypeVariables

--- a/op-energy-backend/op-energy-backend.cabal
+++ b/op-energy-backend/op-energy-backend.cabal
@@ -35,6 +35,7 @@ executable op-energy-backend
                     , text
                     , op-energy-api
                     , monad-logger
+                    , prometheus
     hs-source-dirs:   app
     default-language: Haskell2010
     extensions:       OverloadedStrings
@@ -48,6 +49,7 @@ library
                    , OpEnergy.Server.V1.Config
                    , OpEnergy.Server.V1.DB
                    , OpEnergy.Server.V1.Class
+                   , OpEnergy.Server.V1.Metrics
                    , OpEnergy.Server.V1.BlockHeadersService
                    , OpEnergy.Server.V1.WebSocketService
                    , OpEnergy.Server.V1.WebSocketService.Message
@@ -85,6 +87,7 @@ library
                     , transformers
                     , warp
                     , monad-logger
+                    , prometheus
     ghc-options:    -O2 -Wall -Werror -Wno-unticked-promoted-constructors -fno-warn-name-shadowing -Wno-orphans
     extensions:       OverloadedStrings
                     , ScopedTypeVariables

--- a/op-energy-backend/op-energy-backend.cabal
+++ b/op-energy-backend/op-energy-backend.cabal
@@ -35,11 +35,12 @@ executable op-energy-backend
                     , text
                     , op-energy-api
                     , monad-logger
-                    , prometheus
+                    , prometheus-client
+                    , wai-middleware-prometheus
     hs-source-dirs:   app
     default-language: Haskell2010
     extensions:       OverloadedStrings
-    ghc-options:    -O2 -threaded -rtsopts
+    ghc-options:    -O2 -threaded -rtsopts "-with-rtsopts=-T -N"
 
 library
     hs-source-dirs: src
@@ -87,7 +88,10 @@ library
                     , transformers
                     , warp
                     , monad-logger
-                    , prometheus
+                    , prometheus-client
+                    , wai-middleware-prometheus
+                    , prometheus-metrics-ghc
+                    , prometheus-proc
                     , clock
     ghc-options:    -O2 -Wall -Werror -Wno-unticked-promoted-constructors -fno-warn-name-shadowing -Wno-orphans
     extensions:       OverloadedStrings

--- a/op-energy-backend/src/OpEnergy/Server.hs
+++ b/op-energy-backend/src/OpEnergy/Server.hs
@@ -25,14 +25,14 @@ import           OpEnergy.Server.V1.Config
 import           OpEnergy.Server.V1.Class (AppT, AppM, State(..), defaultState, runAppT, runLogging)
 import           OpEnergy.Server.V1.BlockHeadersService (loadDBState, syncBlockHeaders)
 import           OpEnergy.Server.V1.DB
+import           OpEnergy.Server.V1.Metrics
 
 -- | reads config from file and opens DB connection
-initState :: MonadLoggerIO m => m State
-initState = do
-  config <- liftIO $ OpEnergy.Server.V1.Config.getConfigFromEnvironment
+initState :: MonadLoggerIO m => Config-> MetricsState-> m State
+initState config metrics = do
   pool <- liftIO $ OpEnergy.Server.V1.DB.getConnection config
   logFunc <- askLoggerIO
-  defaultState config logFunc pool
+  defaultState config metrics logFunc pool
 
 -- | Runs HTTP server on a port defined in config in the State datatype
 runServer :: (MonadIO m) => AppT m ()

--- a/op-energy-backend/src/OpEnergy/Server/V1.hs
+++ b/op-energy-backend/src/OpEnergy/Server/V1.hs
@@ -26,6 +26,9 @@ import           OpEnergy.Server.V1.WebSocketService(webSocketConnection)
 import           OpEnergy.Server.V1.BlockSpanService(getBlockSpanList)
 import           OpEnergy.Server.V1.StatisticsService(calculateStatistics)
 
+import           Prometheus(MonadMonitor)
+
+
 -- | here goes implementation of OpEnergy API, which should match Data.OpEnergy.API.V1.V1API
 server:: ServerT V1API (AppT Handler)
 server = OpEnergy.Server.V1.WebSocketService.webSocketConnection
@@ -46,7 +49,7 @@ server = OpEnergy.Server.V1.WebSocketService.webSocketConnection
     :<|> oeGitHashGet
 
 -- | one iteration that called from scheduler thread
-schedulerIteration :: MonadIO m => AppT m ()
+schedulerIteration :: (MonadIO m, MonadMonitor m) => AppT m ()
 schedulerIteration = OpEnergy.Server.V1.BlockHeadersService.syncBlockHeaders
 
 -- returns just commit hash, provided by build system

--- a/op-energy-backend/src/OpEnergy/Server/V1/BlockHeadersService.hs
+++ b/op-energy-backend/src/OpEnergy/Server/V1/BlockHeadersService.hs
@@ -31,6 +31,8 @@ import           Data.Bitcoin.BlockInfo as BlockInfo
 import           Data.OpEnergy.API.V1.Block
 import           OpEnergy.Server.V1.Config
 import           OpEnergy.Server.V1.Class (runLogging, AppT, AppM, State(..))
+import           OpEnergy.Server.V1.Metrics(MetricsState(..))
+import qualified System.Metrics.Prometheus.Metric.Counter as P
 
 
 -- | returns BlockHeader by given hash
@@ -112,7 +114,9 @@ loadDBState = do
 -- | this procedure ensures that BlockHeaders table is in sync with block chain
 syncBlockHeaders :: MonadIO m => AppT m ()
 syncBlockHeaders = do
+  State{ metrics = MetricsState{ syncBlockHeadersCounter = syncBlockHeadersCounter}} <- ask
   runLogging $ $(logDebug) "syncBlockHeaders"
+  liftIO $ P.inc syncBlockHeadersCounter
   mstartSyncHeightFromTo <- mgetHeightToStartSyncFromTo
   case mstartSyncHeightFromTo of
     Nothing-> return () -- do nothing if sync is not needed

--- a/op-energy-backend/src/OpEnergy/Server/V1/BlockHeadersService.hs
+++ b/op-energy-backend/src/OpEnergy/Server/V1/BlockHeadersService.hs
@@ -208,8 +208,10 @@ syncBlockHeaders = do
       where
         persistBlockHeader :: MonadIO m => BlockHeader -> AppT m ()
         persistBlockHeader header = do
-          State{ blockHeadersDBPool = pool } <- ask
-          _ <- liftIO $ flip runSqlPersistMPool pool $ insert header
+          State{ blockHeadersDBPool = pool
+               , metrics = MetricsState { blockHeaderDBInsertH = blockHeaderDBInsertH}
+               } <- ask
+          _ <- liftIO $ P.observeDuration blockHeaderDBInsertH $ flip runSqlPersistMPool pool $ insert header
           return ()
 
         getBlockInfos height = do

--- a/op-energy-backend/src/OpEnergy/Server/V1/BlockHeadersService.hs
+++ b/op-energy-backend/src/OpEnergy/Server/V1/BlockHeadersService.hs
@@ -5,6 +5,7 @@ module OpEnergy.Server.V1.BlockHeadersService
   ( syncBlockHeaders
   , getBlockHeaderByHash
   , getBlockHeaderByHeight
+  , mgetBlockHeaderByHeight
   , loadDBState
   ) where
 

--- a/op-energy-backend/src/OpEnergy/Server/V1/BlockSpanService.hs
+++ b/op-energy-backend/src/OpEnergy/Server/V1/BlockSpanService.hs
@@ -2,22 +2,24 @@
  --}
 module OpEnergy.Server.V1.BlockSpanService where
 
+import           Control.Monad.IO.Class(MonadIO)
 
 import           Data.OpEnergy.API.V1.Block
 import           Data.OpEnergy.API.V1.Positive
 import           Data.OpEnergy.API.V1.Natural
-import           OpEnergy.Server.V1.Class ( AppM)
+import           OpEnergy.Server.V1.Class ( AppT)
 
 
 -- | generates list of block spans starting from given BlockHeight
 getBlockSpanList
-  :: BlockHeight
+  :: MonadIO m
+  => BlockHeight
   -- ^ block span list start
   -> Positive Int
   -- ^ size of spans
   -> Positive Int
   -- ^ number of block spans in resulted list
-  -> AppM [BlockSpan]
+  -> AppT m [BlockSpan]
 getBlockSpanList startHeight span numberOfSpans = return spans
   where
     _span = fromPositive span

--- a/op-energy-backend/src/OpEnergy/Server/V1/Config.hs
+++ b/op-energy-backend/src/OpEnergy/Server/V1/Config.hs
@@ -55,6 +55,8 @@ data Config = Config
     -- ^ how many seconds to wait until ping packet will be sent
   , configLogLevelMin :: LogLevel
     -- ^ minimum log level to display
+  , configPrometheusPort :: Positive Int
+    -- ^ port which should be used by prometheus metrics
   }
   deriving Show
 instance FromJSON Config where
@@ -76,6 +78,7 @@ instance FromJSON Config where
     <*> ( v .:? "STATISTICS_BLOCK_SPANS_COUNT" .!= (configStatisticsBlockSpansCount defaultConfig))
     <*> ( v .:? "WEBSOCKET_KEEP_ALIVE_SECS" .!= (configWebsocketKeepAliveSecs defaultConfig))
     <*> ( v .:? "LOG_LEVEL_MIN" .!= (configLogLevelMin defaultConfig))
+    <*> ( v .:? "PROMETHEUS_PORT" .!= (configPrometheusPort defaultConfig))
 
 defaultConfig:: Config
 defaultConfig = Config
@@ -96,6 +99,7 @@ defaultConfig = Config
   , configStatisticsBlockSpansCount = 100
   , configWebsocketKeepAliveSecs = 10
   , configLogLevelMin = LevelWarn
+  , configPrometheusPort = 7999
   }
 
 getConfigFromEnvironment :: IO Config

--- a/op-energy-backend/src/OpEnergy/Server/V1/Metrics.hs
+++ b/op-energy-backend/src/OpEnergy/Server/V1/Metrics.hs
@@ -3,16 +3,16 @@
  -}
 module OpEnergy.Server.V1.Metrics where
 
-import           System.Clock (Clock(..), diffTimeSpec, getTime, toNanoSecs)
-import           Control.Monad.IO.Class(MonadIO, liftIO)
+-- import           System.Clock (Clock(..), diffTimeSpec, getTime, toNanoSecs)
+import           Control.Monad.IO.Class(MonadIO)
 import           Control.Concurrent.MVar(MVar)
 import qualified Control.Concurrent.MVar as MVar
   
-import qualified System.Metrics.Prometheus.Http.Scrape as P
-import           System.Metrics.Prometheus.Concurrent.RegistryT(RegistryT)
-import qualified System.Metrics.Prometheus.Concurrent.RegistryT as PR
-import qualified System.Metrics.Prometheus.Metric.Histogram as P
-import qualified System.Metrics.Prometheus.Metric.Gauge as P
+import qualified Prometheus as P
+import qualified Network.Wai.Middleware.Prometheus as P
+import qualified Prometheus.Metric.GHC as P
+import qualified Prometheus.Metric.Proc as P
+import qualified Network.Wai.Handler.Warp as W
 
 import           OpEnergy.Server.V1.Config
 import           Data.OpEnergy.API.V1.Positive
@@ -20,44 +20,75 @@ import           Data.OpEnergy.API.V1.Positive
 
 -- | defines the whole state used by backend
 data MetricsState = MetricsState
-  { syncBlockHeadersDuration :: P.Histogram
-  , btcGetBlockchainInfoDuration :: P.Histogram
+  { syncBlockHeadersH :: P.Histogram
+  , btcGetBlockchainInfoH :: P.Histogram
+  , mgetBlockHeaderByHeightH :: P.Histogram
+  , mgetBlockHeaderByHashH :: P.Histogram
+    -- for mgetBlockHeaderByHeight
+  , mgetBlockHeaderByHeightCacheH :: P.Histogram
+  , mgetBlockHeaderByHeightCacheHit :: P.Counter
+  , mgetBlockHeaderByHeightCacheMiss :: P.Counter
+  , mgetBlockHeaderByHeightCacheInsert :: P.Histogram
+  , mgetBlockHeaderByHeightCacheDBLookup :: P.Histogram
+    -- for getBlockHeaderByHash
+  , mgetBlockHeaderByHashCacheH :: P.Histogram
+  , mgetBlockHeaderByHashCacheHit :: P.Counter
+  , mgetBlockHeaderByHashCacheMiss :: P.Counter
+  , mgetBlockHeaderByHashCacheInsert :: P.Histogram
+  , mgetBlockHeaderByHashCacheDBLookup :: P.Histogram
+    -- for getBlockSpanList
+  , getBlockSpanListH :: P.Histogram
+    -- calculateStatistics
+  , calculateStatisticsH :: P.Histogram
   }
 
 -- | constructs default state with given config and DB pool
-initMetrics :: MonadIO m => Config-> RegistryT m MetricsState
+initMetrics :: MonadIO m => Config-> m MetricsState
 initMetrics _config = do
-  syncBlockHeadersDuration <- PR.registerHistogram "syncBlockHeaderDuration" mempty []
-  btcGetBlockchainInfoDuration <- PR.registerHistogram "btcGetBlockchainInfoDuration" mempty []
+  syncBlockHeadersH <- P.register $ P.histogram (P.Info "syncBlockHeader" "") P.defaultBuckets
+  btcGetBlockchainInfoH <- P.register $ P.histogram (P.Info "btcGetBlockchainInfo" "") P.defaultBuckets
+  -- mgetBlockHeaderByHeight
+  mgetBlockHeaderByHeightH <- P.register $ P.histogram (P.Info "mgetBlockHeaderByHeight" "") P.defaultBuckets
+  mgetBlockHeaderByHeightCacheH <- P.register $ P.histogram (P.Info "mgetBlockHeaderByHeightCache" "") P.defaultBuckets
+  mgetBlockHeaderByHeightCacheHit <- P.register $ P.counter (P.Info "mgetBlockHeaderByHeightCacheHit" "")
+  mgetBlockHeaderByHeightCacheMiss <- P.register $ P.counter (P.Info "mgetBlockHeaderByHeightCacheMiss" "")
+  mgetBlockHeaderByHeightCacheInsert <- P.register $ P.histogram (P.Info "mgetBlockHeaderByHeightCacheInsert" "") P.defaultBuckets
+  mgetBlockHeaderByHeightCacheDBLookup <- P.register $ P.histogram (P.Info "mgetBlockHeaderByHeightDBLookup" "") P.defaultBuckets
+  -- getBlockHeaderByHash
+  mgetBlockHeaderByHashH <- P.register $ P.histogram (P.Info "mgetBlockHeaderByHash" "") P.defaultBuckets
+  mgetBlockHeaderByHashCacheH <- P.register $ P.histogram (P.Info "mgetBlockHeaderByHashCache" "") P.defaultBuckets
+  mgetBlockHeaderByHashCacheHit <- P.register $ P.counter (P.Info "mgetBlockHeaderByHashCacheHit" "")
+  mgetBlockHeaderByHashCacheMiss <- P.register $ P.counter (P.Info "mgetBlockHeaderByHashCacheMiss" "")
+  mgetBlockHeaderByHashCacheInsert <- P.register $ P.histogram (P.Info "mgetBlockHeaderByHashCacheInsert" "") P.defaultBuckets
+  mgetBlockHeaderByHashCacheDBLookup <- P.register $ P.histogram (P.Info "mgetBlockHeaderByHashDBLookup" "") P.defaultBuckets
+  -- getBockSpanList
+  getBlockSpanListH <- P.register $ P.histogram (P.Info "getBlockSpanList" "") P.defaultBuckets
+  calculateStatisticsH <- P.register $ P.histogram (P.Info "calculateStatistics" "") P.defaultBuckets
+  _ <- P.register P.ghcMetrics
+  _ <- P.register P.procMetrics
   return $ MetricsState
-    { syncBlockHeadersDuration = syncBlockHeadersDuration
-    , btcGetBlockchainInfoDuration = btcGetBlockchainInfoDuration
+    { syncBlockHeadersH = syncBlockHeadersH
+    , btcGetBlockchainInfoH = btcGetBlockchainInfoH
+    , mgetBlockHeaderByHeightH = mgetBlockHeaderByHeightH
+    , mgetBlockHeaderByHashH = mgetBlockHeaderByHashH
+    , mgetBlockHeaderByHeightCacheH = mgetBlockHeaderByHeightCacheH
+    , mgetBlockHeaderByHeightCacheHit = mgetBlockHeaderByHeightCacheHit
+    , mgetBlockHeaderByHeightCacheMiss = mgetBlockHeaderByHeightCacheMiss
+    , mgetBlockHeaderByHeightCacheInsert = mgetBlockHeaderByHeightCacheInsert
+    , mgetBlockHeaderByHeightCacheDBLookup = mgetBlockHeaderByHeightCacheDBLookup
+    , mgetBlockHeaderByHashCacheH = mgetBlockHeaderByHashCacheH
+    , mgetBlockHeaderByHashCacheHit = mgetBlockHeaderByHashCacheHit
+    , mgetBlockHeaderByHashCacheMiss = mgetBlockHeaderByHashCacheMiss
+    , mgetBlockHeaderByHashCacheInsert = mgetBlockHeaderByHashCacheInsert
+    , mgetBlockHeaderByHashCacheDBLookup = mgetBlockHeaderByHashCacheDBLookup
+    , getBlockSpanListH = getBlockSpanListH
+    , calculateStatisticsH = calculateStatisticsH
     }
 
 -- | runs metrics HTTP server
 runMetricsServer :: Config -> MVar MetricsState -> IO ()
 runMetricsServer config metricsV = do
   let Config{configPrometheusPort = metricsPort } = config
-  PR.runRegistryT $ do
-    metrics <- initMetrics config
-    liftIO $ MVar.putMVar metricsV metrics
-    P.serveMetricsT (fromPositive metricsPort) ["metrics"]
-
-
-observeDurationH :: MonadIO m => P.Histogram -> (m a)-> m a
-observeDurationH h action = do
-  start <- liftIO $ getTime Monotonic
-  ret <- action
-  end <- liftIO $ getTime Monotonic
-  let duration = (fromIntegral (toNanoSecs (end `diffTimeSpec` start))) / 1000000000.0 -- convert to seconds
-  liftIO $ P.observe duration h
-  return ret
-
-observeDurationG :: MonadIO m => P.Gauge -> (m a)-> m a
-observeDurationG h action = do
-  start <- liftIO $ getTime Monotonic
-  ret <- action
-  end <- liftIO $ getTime Monotonic
-  let duration = (fromIntegral (toNanoSecs (end `diffTimeSpec` start))) / 1000000000.0 -- convert to seconds
-  liftIO $ P.set duration h
-  return ret
+  metrics <- initMetrics config
+  MVar.putMVar metricsV metrics
+  W.run (fromPositive metricsPort) P.metricsApp

--- a/op-energy-backend/src/OpEnergy/Server/V1/Metrics.hs
+++ b/op-energy-backend/src/OpEnergy/Server/V1/Metrics.hs
@@ -1,0 +1,39 @@
+{--
+ - This module defines data type that keep all the metrics handlers
+ -}
+module OpEnergy.Server.V1.Metrics where
+
+import           Control.Monad.IO.Class(MonadIO, liftIO)
+import           Control.Concurrent.MVar(MVar)
+import qualified Control.Concurrent.MVar as MVar
+  
+import qualified System.Metrics.Prometheus.Http.Scrape as P
+import           System.Metrics.Prometheus.Concurrent.RegistryT(RegistryT)
+import qualified System.Metrics.Prometheus.Concurrent.RegistryT as PR
+import qualified System.Metrics.Prometheus.Metric.Counter as P
+
+import           OpEnergy.Server.V1.Config
+import           Data.OpEnergy.API.V1.Positive
+
+
+-- | defines the whole state used by backend
+data MetricsState = MetricsState
+  { syncBlockHeadersCounter :: P.Counter
+  }
+
+-- | constructs default state with given config and DB pool
+initMetrics :: MonadIO m => Config-> RegistryT m MetricsState
+initMetrics _config = do
+  syncBlockHeadersCounter <- PR.registerCounter "syncBlockHeader" mempty
+  return $ MetricsState
+    { syncBlockHeadersCounter = syncBlockHeadersCounter
+    }
+
+-- | runs metrics HTTP server
+runMetricsServer :: Config -> MVar MetricsState -> IO ()
+runMetricsServer config metricsV = do
+  let Config{configPrometheusPort = metricsPort } = config
+  PR.runRegistryT $ do
+    metrics <- initMetrics config
+    liftIO $ MVar.putMVar metricsV metrics
+    P.serveMetricsT (fromPositive metricsPort) ["metrics"]

--- a/op-energy-backend/src/OpEnergy/Server/V1/Metrics.hs
+++ b/op-energy-backend/src/OpEnergy/Server/V1/Metrics.hs
@@ -40,6 +40,7 @@ data MetricsState = MetricsState
   , getBlockSpanListH :: P.Histogram
     -- calculateStatistics
   , calculateStatisticsH :: P.Histogram
+  , blockHeaderDBInsertH :: P.Histogram
   }
 
 -- | constructs default state with given config and DB pool
@@ -64,6 +65,7 @@ initMetrics _config = do
   -- getBockSpanList
   getBlockSpanListH <- P.register $ P.histogram (P.Info "getBlockSpanList" "") P.defaultBuckets
   calculateStatisticsH <- P.register $ P.histogram (P.Info "calculateStatistics" "") P.defaultBuckets
+  blockHeaderDBInsertH <- P.register $ P.histogram (P.Info "blockHeaderDBInsertH" "") P.defaultBuckets
   _ <- P.register P.ghcMetrics
   _ <- P.register P.procMetrics
   return $ MetricsState
@@ -83,6 +85,7 @@ initMetrics _config = do
     , mgetBlockHeaderByHashCacheDBLookup = mgetBlockHeaderByHashCacheDBLookup
     , getBlockSpanListH = getBlockSpanListH
     , calculateStatisticsH = calculateStatisticsH
+    , blockHeaderDBInsertH = blockHeaderDBInsertH
     }
 
 -- | runs metrics HTTP server

--- a/op-energy-backend/src/OpEnergy/Server/V1/StatisticsService.hs
+++ b/op-energy-backend/src/OpEnergy/Server/V1/StatisticsService.hs
@@ -7,11 +7,14 @@ import           Control.Monad.Reader (ask)
 import           Control.Monad.IO.Class (MonadIO)
 import qualified Data.List as List
 import           Data.Maybe(fromJust)
+import           Prometheus(MonadMonitor)
+import qualified Prometheus as P
 
 import Data.OpEnergy.API.V1.Block
 import Data.OpEnergy.API.V1.Positive
 import Data.OpEnergy.API.V1 (NbdrStatistics(..), Statistics(..))
 import OpEnergy.Server.V1.Class
+import OpEnergy.Server.V1.Metrics
 import OpEnergy.Server.V1.Config
 import OpEnergy.Server.V1.BlockSpanService
 import OpEnergy.Server.V1.BlockHeadersService
@@ -20,26 +23,31 @@ import OpEnergy.Server.V1.BlockHeadersService
 -- which shows how fast blocks had been discovered: if it less than 100% - then blocks in block span are being discovered slower than theoretical speed. If it more than 100% - faster.
 -- current implementation will try to calculate statistics for 'configStatisticsBlockSpansCount' spans of size 'span' starting from 'startHeight' block
 calculateStatistics
-  :: MonadIO m
+  :: ( MonadIO m
+     , MonadMonitor m
+     )
   => BlockHeight
   -- ^ starting block height of a range for which statistics will be generated
   -> Positive Int
   -- ^ size of block span
   -> AppT m Statistics
 calculateStatistics startHeight span = do
-  State{ config = Config { configStatisticsBlockSpansCount = statisticsBlockSpansCount}} <- ask
-  blockSpans <- getBlockSpanList startHeight span $! positiveFromPositive2 statisticsBlockSpansCount
-  let theoreticalBlockSpanTime = span * 600
-      theoreticalBlockSpanTimePercent = theoreticalBlockSpanTime * 100
-  discoverSpeeds::[Double] <- forM blockSpans $ \(BlockSpan start end) -> do
-    startBlock <- mgetBlockHeaderByHeight start >>= pure . fromJust
-    endBlock <- mgetBlockHeaderByHeight end >>= pure . fromJust
-    return $! (fromIntegral theoreticalBlockSpanTimePercent) / ((fromIntegral (blockHeaderMediantime endBlock)) - (fromIntegral (blockHeaderMediantime startBlock)))
-  let avg = (List.foldl' (\acc v -> acc + v) 0.0 discoverSpeeds ) / (fromIntegral statisticsBlockSpansCount)
-      stddev = sqrt $! (List.foldl' (\acc i-> acc + (i - avg) ^ (2 :: Int)) 0.0 discoverSpeeds) / (fromIntegral ((unPositive2 statisticsBlockSpansCount) - 1))
-  return $ Statistics
-    { nbdr = NbdrStatistics
-      { avg = avg
-      , stddev = stddev
+  State{ config = Config { configStatisticsBlockSpansCount = statisticsBlockSpansCount}
+       , metrics = MetricsState { calculateStatisticsH = calculateStatisticsH}
+       } <- ask
+  P.observeDuration calculateStatisticsH $ do
+    blockSpans <- getBlockSpanList startHeight span $! positiveFromPositive2 statisticsBlockSpansCount
+    let theoreticalBlockSpanTime = span * 600
+        theoreticalBlockSpanTimePercent = theoreticalBlockSpanTime * 100
+    discoverSpeeds::[Double] <- forM blockSpans $ \(BlockSpan start end) -> do
+      startBlock <- mgetBlockHeaderByHeight start >>= pure . fromJust
+      endBlock <- mgetBlockHeaderByHeight end >>= pure . fromJust
+      return $! (fromIntegral theoreticalBlockSpanTimePercent) / ((fromIntegral (blockHeaderMediantime endBlock)) - (fromIntegral (blockHeaderMediantime startBlock)))
+    let avg = (List.foldl' (\acc v -> acc + v) 0.0 discoverSpeeds ) / (fromIntegral statisticsBlockSpansCount)
+        stddev = sqrt $! (List.foldl' (\acc i-> acc + (i - avg) ^ (2 :: Int)) 0.0 discoverSpeeds) / (fromIntegral ((unPositive2 statisticsBlockSpansCount) - 1))
+    return $ Statistics
+      { nbdr = NbdrStatistics
+        { avg = avg
+        , stddev = stddev
+        }
       }
-    }

--- a/op-energy-backend/src/OpEnergy/Server/V1/WebSocketService.hs
+++ b/op-energy-backend/src/OpEnergy/Server/V1/WebSocketService.hs
@@ -15,7 +15,7 @@ import qualified Control.Concurrent.STM as STM
 import qualified Control.Concurrent.STM.TVar as TVar
 import           Network.WebSockets ( Connection, receiveData, withPingThread, sendTextData)
 
-import           OpEnergy.Server.V1.Class (runLogging, AppT, AppM, State(..), runAppT)
+import           OpEnergy.Server.V1.Class (runLogging, AppT, State(..), runAppT)
 import           Data.OpEnergy.API.V1.Hash( Hash, generateRandomHash)
 import           Data.OpEnergy.API.V1.Block( BlockHeight, BlockHeader(..))
 import           Data.OpEnergy.API.V1.Positive(naturalFromPositive)
@@ -28,7 +28,7 @@ import           OpEnergy.Server.V1.Config
 -- - handles requests from clients;
 -- - sends notification about newest confirmed block
 -- - sends keepalive packets
-webSocketConnection :: Connection-> AppM ()
+webSocketConnection :: MonadIO m => Connection-> AppT m ()
 webSocketConnection conn = do
   state <- ask
   liftIO $ bracket (runAppT state $ initConnection state) (\uuid -> runAppT state $ closeConnection state uuid) $ \(uuid, witnessedHeightV)-> do


### PR DESCRIPTION
This PR adds support of exposing performance metrics:
- New config variable "PROMETHEUS_PORT" with default value 7999. This port will be sending metrics in prometheus format to HTTP clients/collectors;
- dependency on prometheus-client, wait-middleware-prometeus, prometheus-proc and prometeus-metrics-ghc;
- exposes aggregated durations and counts of API calls, cache insertion/lookup, DB BlockHeader lookup/insertion;
- exposes runtime system metrics (mostly garbage-collector related);
- exposes memory stats (vm, residental memory).