### PR TITLE
359 introduce api call to return block headers by blockspan

### DIFF
--- a/frontend/src/app/oe/interfaces/op-energy.interface.ts
+++ b/frontend/src/app/oe/interfaces/op-energy.interface.ts
@@ -76,3 +76,9 @@ export interface BlockHeader {
   chainwork: string;
   mediantime: number;
 }
+
+export interface BlockSpanHeadersNbdr {
+  startBlock: BlockHeader;
+  endBlock: BlockHeader;
+  nbdr: number;
+}

--- a/frontend/src/app/oe/services/op-energy.service.ts
+++ b/frontend/src/app/oe/services/op-energy.service.ts
@@ -162,6 +162,10 @@ export class OpEnergyApiService {
     return this.httpClient.get<EnergyNbdrStatistics>(`${this.apiBaseUrl}${this.apiBasePath}/api/v1/statistics/${blockHeight}/${span}`);
   }
 
+  $getBlocksByBlockSpan(startBlockHeight: number, span: number, numberOfSpan: number): Observable<BlockHeader[][]> {
+    return this.httpClient.get<BlockHeader[][]>(`${this.apiBaseUrl}${this.apiBasePath}/api/v1/oe/blocksbyblockspan/${startBlockHeight}/${span}/${numberOfSpan}`);
+  }
+
   $getBlockSpanList(startBlockHeight: number, span: number, numberOfSpan: number): Observable<BlockSpan[]> {
     return this.httpClient.get<BlockSpan[]>(`${this.apiBaseUrl}${this.apiBasePath}/api/v1/oe/blockspanlist/${startBlockHeight}/${span}/${numberOfSpan}`);
   }

--- a/frontend/src/app/oe/services/op-energy.service.ts
+++ b/frontend/src/app/oe/services/op-energy.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { ReplaySubject, BehaviorSubject, Subject, fromEvent, Observable } from 'rxjs';
 import { HttpParams, HttpClient } from '@angular/common/http';
-import { TimeStrike, SlowFastGuess, SlowFastGuessOutcome, TimeStrikesHistory, SlowFastResult, EnergyNbdrStatistics, BlockSpan, BlockHeader } from '../interfaces/op-energy.interface';
+import { TimeStrike, SlowFastGuess, SlowFastGuessOutcome, TimeStrikesHistory, SlowFastResult, EnergyNbdrStatistics, BlockSpan, BlockHeader, BlockSpanHeadersNbdr } from '../interfaces/op-energy.interface';
 import { StateService } from '../../services/state.service';
 import { WebsocketService } from 'src/app/services/websocket.service';
 import { Block } from 'src/app/interfaces/electrs.interface';
@@ -164,6 +164,10 @@ export class OpEnergyApiService {
 
   $getBlocksByBlockSpan(startBlockHeight: number, span: number, numberOfSpan: number): Observable<BlockHeader[][]> {
     return this.httpClient.get<BlockHeader[][]>(`${this.apiBaseUrl}${this.apiBasePath}/api/v1/oe/blocksbyblockspan/${startBlockHeight}/${span}/${numberOfSpan}`);
+  }
+
+  $getBlocksWithNbdrByBlockSpan(startBlockHeight: number, span: number, numberOfSpan: number): Observable<BlockSpanHeadersNbdr[]> {
+    return this.httpClient.get<BlockSpanHeadersNbdr[]>(`${this.apiBaseUrl}${this.apiBasePath}/api/v1/oe/blockswithnbdrbyblockspan/${startBlockHeight}/${span}/${numberOfSpan}`);
   }
 
   $getBlockSpanList(startBlockHeight: number, span: number, numberOfSpan: number): Observable<BlockSpan[]> {

--- a/op-energy-api/src/Data/OpEnergy/API/V1.hs
+++ b/op-energy-api/src/Data/OpEnergy/API/V1.hs
@@ -109,6 +109,14 @@ type V1API
     :> Get '[JSON] BlockHeader
 
   :<|> "oe"
+    :> "blocksbyblockspan"
+    :> Capture "startBlockHeight" BlockHeight
+    :> Capture "span" (Positive Int)
+    :> Capture "numberOfSpan" (Positive Int)
+    :> Description "Returns list of blocks' headers by a given block span. Answer format: [ [startBlockHeight, startBlockHeight + span], [startBlockHeight + span, ...], ... ]"
+    :> Get '[JSON] [[BlockHeader]]
+
+  :<|> "oe"
     :> "blockspanlist"
     :> Capture "startBlockHeight" BlockHeight
     :> Capture "span" (Positive Int)

--- a/op-energy-api/src/Data/OpEnergy/API/V1.hs
+++ b/op-energy-api/src/Data/OpEnergy/API/V1.hs
@@ -93,7 +93,7 @@ type V1API
   :<|> "statistics"
     :> Capture "blockheight" BlockHeight
     :> Capture "span" (Positive Int)
-    :> Description "Calculates NBDR statistics for a given block height and span"
+    :> Description "Calculates NBDR statistics for a given block height and span. NBDR here is ratio (span * 600 * 100) / (endBlockMedianTime - startBlockMediantime)."
     :> Get '[JSON] Statistics
 
   :<|> "oe"
@@ -115,6 +115,14 @@ type V1API
     :> Capture "numberOfSpan" (Positive Int)
     :> Description "Returns list of blocks' headers by a given block span. Answer format: [ [startBlockHeight, startBlockHeight + span], [startBlockHeight + span, ...], ... ]"
     :> Get '[JSON] [[BlockHeader]]
+
+  :<|> "oe"
+    :> "blockswithnbdrbyblockspan"
+    :> Capture "startBlockHeight" BlockHeight
+    :> Capture "span" (Positive Int)
+    :> Capture "numberOfSpan" (Positive Int)
+    :> Description "Returns list of start and end blocks' headers and their nbdr for each appropriate block span. NBDR here is ratio (span * 600 * 100) / (endBlockMedianTime - startBlockMediantime)."
+    :> Get '[JSON] [BlockSpanHeadersNbdr]
 
   :<|> "oe"
     :> "blockspanlist"
@@ -150,6 +158,25 @@ instance ToSchema GitHashResponse where
 defaultGitHashResponse :: GitHashResponse
 defaultGitHashResponse = GitHashResponse
   { gitCommitHash = "12345678"
+  }
+
+data BlockSpanHeadersNbdr = BlockSpanHeadersNbdr
+  { startBlock :: BlockHeader
+  , endBlock :: BlockHeader
+  , nbdr :: Double
+  }
+  deriving (Show, Generic, Typeable)
+instance ToJSON   BlockSpanHeadersNbdr
+instance FromJSON BlockSpanHeadersNbdr
+instance ToSchema BlockSpanHeadersNbdr where
+  declareNamedSchema proxy = genericDeclareNamedSchema defaultSchemaOptions proxy
+    & mapped.schema.description ?~ "BlockSpanHeadersNbdr schema"
+    & mapped.schema.example ?~ toJSON defaultBlockSpanHeadersNbdr
+defaultBlockSpanHeadersNbdr :: BlockSpanHeadersNbdr
+defaultBlockSpanHeadersNbdr = BlockSpanHeadersNbdr
+  { startBlock = defaultBlockHeader
+  , endBlock = defaultBlockHeader
+  , nbdr = 100.0
   }
 
 data NbdrStatistics = NbdrStatistics

--- a/op-energy-api/src/Data/OpEnergy/API/V1/Hash.hs
+++ b/op-energy-api/src/Data/OpEnergy/API/V1/Hash.hs
@@ -11,6 +11,8 @@ module Data.OpEnergy.API.V1.Hash where
 
 import           Data.Text                  (Text)
 import qualified Data.Text as               T
+import           Data.ByteString.Short( ShortByteString)
+import qualified Data.ByteString.Short as BS (toShort, fromShort)
 import           GHC.Generics
 import           Data.Typeable              (Typeable)
 import           Data.Aeson
@@ -29,27 +31,29 @@ import           System.Random
 import           Database.Persist
 import           Database.Persist.Sql
 
-data Hash = Hash Text
+newtype Hash = Hash ShortByteString -- ShortByteString here is just because
+               -- regular ByteString is not compatible with Compact regions
   deriving (Show, Generic, Typeable, Eq, Ord)
-instance ToJSON Hash
-instance FromJSON Hash
+instance ToJSON Hash where
+  toJSON (Hash s) = toJSON $! TE.decodeUtf8 $! BS.fromShort s
+instance FromJSON Hash where
+  parseJSON = withText "Hash" $ \v-> return $! verifyHash v
 instance ToParamSchema Hash where
   toParamSchema _ = mempty
     & type_ ?~ SwaggerString
     & format ?~ "b8ab3013e4adb35fae6cbdc9d84c86cd280157b7a93b984c0b40baf7f21b8f72"
 instance ToHttpApiData Hash where
-  toUrlPiece (Hash t) = toUrlPiece t
-  toQueryParam (Hash t) = toQueryParam t
+  toUrlPiece (Hash t) = toUrlPiece $! TE.decodeUtf8 $! BS.fromShort t
+  toQueryParam (Hash t) = toQueryParam $! TE.decodeUtf8 $! BS.fromShort t
 instance ToSchema Hash where
-  declareNamedSchema proxy = genericDeclareNamedSchema defaultSchemaOptions proxy
-    & mapped.schema.description ?~ "Hash schema"
-    & mapped.schema.example ?~ toJSON ((Hash "b8ab3013e4ddb35fae6cedc9d84c86fd280157b7a93b984c0b40baf7f21b8f72") )
+  declareNamedSchema _ = pure $ NamedSchema (Just "Hash") $ mempty
+    & type_ ?~ SwaggerString
 instance FromHttpApiData Hash where
   parseUrlPiece t = Right (verifyHash t)
   parseQueryParam t = Right (verifyHash t)
 
 instance PersistField Hash where
-  toPersistValue (Hash s) = toPersistValue s
+  toPersistValue (Hash s) = toPersistValue $! TE.decodeUtf8 $! BS.fromShort s
   fromPersistValue (PersistText s) = Right $! verifyHash s -- TODO
   fromPersistValue _ = Left $ "InputVerification.hs fromPersistValue Hash , expected Text"
 instance PersistFieldSql Hash where
@@ -63,14 +67,14 @@ generateRandomHash :: IO Hash
 generateRandomHash = do
   rndBS <- (replicateM 10 $ getStdRandom (randomR (0::Word8, 255::Word8))) >>= return . BS.pack
   let base16 = Base16.encode $! hash rndBS
-  return $! Hash $! TE.decodeUtf8 base16
+  return $! Hash $! BS.toShort $! base16
 
 everifyHash:: Text-> Either Text Hash
 everifyHash raw =
   case () of
     _ | T.length limitedSize /= 64 -> Left "Hash: wrong size"
     _ | not (T.all isAlphaNum limitedSize ) -> Left "Hash: should be alpha num"
-    _ -> Right (Hash limitedSize)
+    _ -> Right (Hash $! BS.toShort $! TE.encodeUtf8 limitedSize)
   where
     limitedSize = T.copy $! T.take 64 raw
 

--- a/op-energy-backend/op-energy-backend.cabal
+++ b/op-energy-backend/op-energy-backend.cabal
@@ -52,6 +52,10 @@ library
                    , OpEnergy.Server.V1.Class
                    , OpEnergy.Server.V1.Metrics
                    , OpEnergy.Server.V1.BlockHeadersService
+--                    , OpEnergy.Server.V1.BlockHeadersService.Map.Cache
+--                    , OpEnergy.Server.V1.BlockHeadersService.Map.Service
+                   , OpEnergy.Server.V1.BlockHeadersService.Vector.Cache
+                   , OpEnergy.Server.V1.BlockHeadersService.Vector.Service
                    , OpEnergy.Server.V1.WebSocketService
                    , OpEnergy.Server.V1.WebSocketService.Message
                    , OpEnergy.Server.V1.BlockSpanService
@@ -95,7 +99,10 @@ library
                     , prometheus-proc
                     , async
                     , unliftio-core
+                    , vector
+                    , ghc-compact
     ghc-options:    -O2 -Wall -Werror -Wno-unticked-promoted-constructors -fno-warn-name-shadowing -Wno-orphans
     extensions:       OverloadedStrings
                     , ScopedTypeVariables
+                    , BangPatterns
 

--- a/op-energy-backend/src/OpEnergy/Server/V1/BlockHeadersService/Vector/Cache.hs
+++ b/op-energy-backend/src/OpEnergy/Server/V1/BlockHeadersService/Vector/Cache.hs
@@ -1,0 +1,55 @@
+{-- | This module provides block headers cache based on 2-dimensional vector, such that lookup and insert time is expected to be O(1)
+ -}
+{-# LANGUAGE TemplateHaskell     #-}
+module OpEnergy.Server.V1.BlockHeadersService.Vector.Cache
+  ( BlockHeadersCache(..)
+  , BlockHeadersCaches(..)
+  , init
+  ) where
+
+import           Prelude hiding (init)
+import           Control.Concurrent.MVar (MVar)
+import qualified Control.Concurrent.MVar as MVar
+import           Data.Map.Strict( Map)
+import qualified Data.Map.Strict as Map
+import           Control.Monad.IO.Class (liftIO, MonadIO)
+import           Data.Vector(Vector)
+import           Data.Vector.Mutable(IOVector)
+import qualified Data.Vector.Mutable as VM
+import           GHC.Compact (Compact)
+import qualified GHC.Compact as Compact
+
+import           Data.OpEnergy.API.V1.Block
+import           Data.OpEnergy.API.V1.Positive
+import           OpEnergy.Server.V1.Config
+
+data BlockHeadersCaches = BlockHeadersCaches
+  { immutableHeightCache :: IOVector (Compact(Vector BlockHeader))
+    -- ^ this is immutable part of cache that keeps all the blocks older than tip - configCacheChunkSize
+  , mutableHeightCache :: IOVector BlockHeader
+    -- ^ this is mutable part of cache that keeps newer than tip - configCacheChunkSize blocks. As soon as it will be filled, it will move to immutable cache
+  , hashCache :: Compact( Map BlockHash BlockHeight)
+    -- ^ immutable cache of Hash -> Height map. This is needed as we support /api/v1/oe/block call, which requires hash -> block association
+  , cacheTop :: Maybe BlockHeight
+  -- ^ this is the pointer to cache top. It is expected, that cache is only filled monotonically from the bottom (index 0), such that there should be no holes
+  }
+
+-- | Wrapper for a type. MVar is used here as it is difficult to update Cache in
+-- STM as such update requires IO action (mutable vectors? compact regions, etc).
+-- It is expected, that cache write will use takeMVar/putMVar. Cache read requires only readMVar
+newtype BlockHeadersCache = BlockHeadersCache (MVar BlockHeadersCaches)
+
+init
+  :: MonadIO m
+  => Config
+  -> m BlockHeadersCache
+init (Config{ configCacheChunkSize = configCacheChunkSize})= do
+  mutableCache <- liftIO $ VM.new (fromPositive configCacheChunkSize)
+  immutableCache <- liftIO $ VM.new 0
+  hashCache <- liftIO $ Compact.compact Map.empty
+  v <- liftIO $ MVar.newMVar (BlockHeadersCaches { immutableHeightCache = immutableCache
+                                                 , mutableHeightCache = mutableCache
+                                                 , hashCache = hashCache
+                                                 , cacheTop = Nothing
+                                                 } )
+  return (BlockHeadersCache v)

--- a/op-energy-backend/src/OpEnergy/Server/V1/BlockHeadersService/Vector/Service.hs
+++ b/op-energy-backend/src/OpEnergy/Server/V1/BlockHeadersService/Vector/Service.hs
@@ -1,0 +1,188 @@
+{-- | This module provides block headers cache based on 2-dimensional vector, such
+ -- that lookup and insert time is expected to be O(1)
+ -}
+{-# LANGUAGE TemplateHaskell     #-}
+module OpEnergy.Server.V1.BlockHeadersService.Vector.Service
+  ( insertEnsureCapacity
+  , maybeInsert
+  , maybeInsertMany
+  , lookupByHeight
+  , lookupByHash
+  , ensureCapacity
+  ) where
+
+import           Data.IORef(newIORef, readIORef, writeIORef)
+import qualified Control.Concurrent.MVar as MVar
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Control.Monad(when, foldM)
+import           Control.Monad.Trans.Reader (ask)
+import           Control.Monad.IO.Class (MonadIO, liftIO)
+import           Control.Monad.Logger (logDebug)
+import           Data.Vector(Vector, (!))
+import qualified Data.Vector as V
+import           Data.Vector.Mutable(IOVector)
+import qualified Data.Vector.Mutable as VM
+import           Control.Exception(bracket)
+import           GHC.Compact (Compact)
+import qualified GHC.Compact as Compact
+
+import           Data.OpEnergy.API.V1.Block
+import           Data.OpEnergy.API.V1.Natural
+import           Data.OpEnergy.API.V1.Positive
+import           OpEnergy.Server.V1.Config
+import           OpEnergy.Server.V1.Class ( runAppT, runLogging, AppT, State(..))
+import           OpEnergy.Server.V1.Metrics hiding (blockHeaderHeightCacheEnsureCapacity)
+import           OpEnergy.Server.V1.BlockHeadersService.Vector.Cache
+import           Data.Text.Show(tshow)
+
+import           Prometheus(MonadMonitor)
+import qualified Prometheus as P
+
+-- | This function tries to lookup BlockHeader from cache by given block height.
+lookupByHeight
+  :: ( MonadIO m
+     , MonadMonitor m
+     )
+  => BlockHeight
+  -> AppT m (Maybe BlockHeader)
+lookupByHeight height = do
+  State{ config = Config { configCacheChunkSize = configCacheChunkSize }
+       , blockHeadersCache = BlockHeadersCache cacheV
+       , metrics = MetricsState { blockHeaderHeightCacheH = blockHeaderHeightCacheH
+                                , blockHeaderHeightCacheHit = blockHeaderHeightCacheHit
+                                , blockHeaderHeightCacheMiss = blockHeaderHeightCacheMiss
+                                }
+       } <- ask
+  P.observeDuration blockHeaderHeightCacheH $ do
+    BlockHeadersCaches {immutableHeightCache = immutableHeightCache, mutableHeightCache = mutableHeightCache, cacheTop = mcacheTop} <- liftIO $ MVar.readMVar cacheV
+    case mcacheTop of
+      Nothing -> do  -- nothing had been cached yet
+        P.incCounter blockHeaderHeightCacheMiss
+        return Nothing
+      Just cacheTop
+        | height > cacheTop -> do -- haven't witnessed such height yet
+            P.incCounter blockHeaderHeightCacheMiss
+            return Nothing
+        | otherwise -> do
+          let (row,col) = height `divMod` (naturalFromPositive configCacheChunkSize)
+              immutableRow = cacheTop `div` (naturalFromPositive configCacheChunkSize)
+          if row == immutableRow
+            then do -- requested height is currently in the mutable cache
+              header <- liftIO $ VM.read mutableHeightCache (fromNatural col)
+              P.incCounter blockHeaderHeightCacheHit
+              return (Just header)
+            else do -- requested height is currently in the immutable cache
+              !colCache <- liftIO $ VM.read immutableHeightCache (fromNatural row)
+              let !header = (Compact.getCompact colCache) ! (fromNatural col)
+              P.incCounter blockHeaderHeightCacheHit
+              return (Just header)
+              
+
+-- | This function tries to lookup BlockHeader from cache by given block hash
+lookupByHash
+  :: ( MonadIO m
+     , MonadMonitor m
+     )
+  => BlockHash
+  -> AppT m (Maybe BlockHeader)
+lookupByHash hash = do
+  State{ blockHeadersCache = BlockHeadersCache cacheV
+       , metrics = MetricsState { blockHeaderHashCacheH = blockHeaderHashCacheH
+                                , blockHeaderHashCacheHit = blockHeaderHashCacheHit
+                                , blockHeaderHashCacheMiss = blockHeaderHashCacheMiss
+                                }
+       } <- ask
+  mheight <- P.observeDuration blockHeaderHashCacheH $ do
+    BlockHeadersCaches { hashCache = hashCache}  <- liftIO $ MVar.readMVar cacheV
+    case Map.lookup hash (Compact.getCompact hashCache) of
+      Nothing -> do
+        P.incCounter blockHeaderHashCacheMiss
+        return Nothing
+      Just height -> do
+        P.incCounter blockHeaderHashCacheHit
+        return (Just height)
+  case mheight of
+    Nothing -> return Nothing
+    Just height -> lookupByHeight height
+
+-- | try to insert header into block header cache.
+maybeInsert
+  :: MonadIO m
+  => BlockHeader
+  -> AppT m ()
+maybeInsert !header = maybeInsertMany [header]
+
+-- perform bulk insert into cache
+maybeInsertMany
+  :: MonadIO m
+  => [BlockHeader]
+  -> AppT m ()
+maybeInsertMany headers = do
+  state@State{ config = Config { configCacheChunkSize = configCacheChunkSize }
+             , blockHeadersCache = BlockHeadersCache cacheV
+             , metrics = MetricsState { blockHeaderHeightCacheInsert = blockHeaderHeightCacheInsert
+                                      , blockHeaderHashCacheInsert = blockHeaderHashCacheInsert
+                                      }
+             } <- ask
+  failedV <- liftIO $ newIORef True -- set default failed flag to True, which on success should be changed to False
+  liftIO $ bracket
+    (MVar.takeMVar cacheV) -- read cache state
+    (\v -> readIORef failedV >>= \failed-> when failed (MVar.putMVar cacheV v)) -- if failed - put back an old state
+    $ \cache@(BlockHeadersCaches { immutableHeightCache = immutableHeightCache, mutableHeightCache = mutableHeightCache, cacheTop = mcacheTop, hashCache = hashCache}) -> do
+      let forEach :: (IOVector (Compact(Vector BlockHeader)), IOVector BlockHeader, Map BlockHash BlockHeight, Maybe BlockHeight) -> BlockHeader -> IO (IOVector (Compact(Vector BlockHeader)), IOVector BlockHeader, Map BlockHash BlockHeight, Maybe BlockHeight)
+          forEach (immutableHeightCache, mutableHeightCache, hashCache, mcacheTop) header = do
+            let (row, col) = blockHeaderHeight header `divMod` (naturalFromPositive configCacheChunkSize)
+            case mcacheTop of
+              Nothing
+                | blockHeaderHeight header > 0 -> error "you are trying to cache block header not from the 0 block. This will create a hole and will cause exceptions in the future! Cache from block 0"
+                | otherwise -> do -- mutable height cache should be already there
+                    P.observeDuration blockHeaderHeightCacheInsert $! VM.write mutableHeightCache 0 header
+                    !newHashCache <- P.observeDuration blockHeaderHeightCacheInsert $ return $! Map.insert (blockHeaderHash header) (blockHeaderHeight header) hashCache
+                    return (immutableHeightCache, mutableHeightCache, newHashCache, Just (blockHeaderHeight header))
+              Just cacheTop
+                | blockHeaderHeight header <= cacheTop -> return ( immutableHeightCache, mutableHeightCache, hashCache, mcacheTop) -- do nothing, given block header should already be cached
+                | blockHeaderHeight header - cacheTop > 1 -> error "cached block headers' heights should be monotonically increasing, otherwise there will be undefined behavior"
+                | otherwise -> do -- error cases checked, should be safe to continue
+                  let mutableRow = cacheTop `div` (naturalFromPositive configCacheChunkSize)
+                  if mutableRow == row
+                    then do -- we can just insert given header into currently mutable height cache
+                      P.observeDuration blockHeaderHeightCacheInsert $! do
+                        VM.write mutableHeightCache (fromNatural col) header
+                        return ()
+                      !newHashCache <- P.observeDuration blockHeaderHashCacheInsert $ return $! Map.insert (blockHeaderHash header) (blockHeaderHeight header) hashCache
+                      return (immutableHeightCache, mutableHeightCache, newHashCache, Just (blockHeaderHeight header))
+                    else do -- looks like 'header' should be inserted into the next chunk. We need to store current chunk and create new one
+                      runAppT state $ runLogging $ $(logDebug) $! "in order to insert block " <> tshow (blockHeaderHeight header) <> " we need to grow cache chunk: mutableRow" <> tshow mutableRow <> ", row : " <> tshow row <> ", cacheChunkSize: " <> tshow configCacheChunkSize
+                      newImmutableHeightCache <- P.observeDuration blockHeaderHeightCacheInsert $! do
+                        newRow <- V.freeze mutableHeightCache >>= Compact.compact -- convert to immutable vector and move to out of GC region
+                        newImmutableHeightCache <- VM.grow immutableHeightCache 1 -- ensure we have a memory
+                        VM.write newImmutableHeightCache (fromNatural mutableRow) newRow -- store previously mutable cache
+                        newMutableHeightCache <- VM.new (fromPositive configCacheChunkSize) -- recreate new mutable cache
+                        VM.write newMutableHeightCache (fromNatural col) header
+                        return newImmutableHeightCache
+                      !newHashCache <- P.observeDuration blockHeaderHashCacheInsert $ return $! Map.insert (blockHeaderHash header) (blockHeaderHeight header) hashCache
+                      return (newImmutableHeightCache, mutableHeightCache, newHashCache, Just (blockHeaderHeight header))
+      (newImmutableHeightCache, newMutableHeightCache, newHashCache, newCacheTop) <- foldM forEach (immutableHeightCache, mutableHeightCache, Compact.getCompact hashCache, mcacheTop) headers
+      newHashCacheC <- Compact.compact newHashCache
+      MVar.putMVar cacheV (cache { immutableHeightCache = newImmutableHeightCache, mutableHeightCache = newMutableHeightCache, cacheTop = newCacheTop, hashCache = newHashCacheC})
+      writeIORef failedV False -- mark a flag that everything went fine
+      return ()
+
+-- | this procedure should ensure, that there is enough capacity to store the
+-- upper bound of cache. Currenty, this procedure does nothing as data structure
+--implies dynamic resize instead of container pre-allocating 
+ensureCapacity
+  :: ( MonadIO m
+     , MonadMonitor m
+     )
+  => BlockHeight
+  -> AppT m ()
+ensureCapacity _ = return ()
+  
+  
+-- | ensureCapacity and then maybeInsert
+insertEnsureCapacity :: (MonadIO m, MonadMonitor m) => BlockHeader-> AppT m ()
+insertEnsureCapacity header = do
+  ensureCapacity (blockHeaderHeight header)
+  maybeInsert header

--- a/op-energy-backend/src/OpEnergy/Server/V1/Class.hs
+++ b/op-energy-backend/src/OpEnergy/Server/V1/Class.hs
@@ -9,15 +9,15 @@ import           Control.Monad.Trans.Reader (runReaderT, ReaderT, ask)
 import           Control.Monad.IO.Class (MonadIO, liftIO)
 import           Control.Monad.Trans(lift)
 import           Control.Monad.Logger (runLoggingT, filterLogger, LoggingT, MonadLoggerIO, Loc, LogSource, LogLevel, LogStr)
-import           Data.Map (Map)
 import qualified Data.Map as Map
 import           Servant (Handler)
-
-import           Data.OpEnergy.API.V1.Block (BlockHash, BlockHeight, BlockHeader)
-import           OpEnergy.Server.V1.Config
-import           OpEnergy.Server.V1.Metrics
 import           Data.Pool(Pool)
 import           Database.Persist.Postgresql (SqlBackend)
+
+import           Data.OpEnergy.API.V1.Block ( BlockHeader)
+import           OpEnergy.Server.V1.Config
+import           OpEnergy.Server.V1.Metrics
+import           OpEnergy.Server.V1.BlockHeadersService.Vector.Cache as Cache
 
 type LogFunc = Loc -> LogSource -> LogLevel -> LogStr -> IO ()
 
@@ -27,10 +27,8 @@ data State = State
   -- ^ app config, loaded from file
   , blockHeadersDBPool :: Pool SqlBackend
   -- ^ DB connection pool to BlockHeadersDB
-  , blockHeadersHeightCache :: TVar (Map BlockHeight BlockHeader)
-  -- ^ BlockHeaders' cache: BlockHeight -> BlockHeader. At the moment, cache is not expireable
-  , blockHeadersHashCache :: TVar (Map BlockHash BlockHeight)
-  -- ^ BlockHeaders' cache: BlockHash -> BlockHeight. At the moment, cache is not expireable
+  , blockHeadersCache :: BlockHeadersCache
+  -- ^ BlockHeaders' cache
   , currentTip :: TVar (Maybe BlockHeader)
   -- ^ defines the newest witnessed confirmed block
   , logFunc :: LogFunc
@@ -45,14 +43,13 @@ type AppM = ReaderT State Handler
 -- | constructs default state with given config and DB pool
 defaultState :: (MonadLoggerIO m ) => Config-> MetricsState-> LogFunc-> Pool SqlBackend-> m State
 defaultState config metrics logFunc _blockHeadersDBPool = do
-  _blockHeadersHeightCache <- liftIO $ TVar.newTVarIO Map.empty
+  _blockHeadersCache <- Cache.init config
   _blockHeadersHashCache <- liftIO $ TVar.newTVarIO Map.empty
   _currentTip <- liftIO $ TVar.newTVarIO Nothing
   logLevelV <- liftIO $ TVar.newTVarIO (configLogLevelMin config)
   return $ State
     { config = config
-    , blockHeadersHeightCache = _blockHeadersHeightCache
-    , blockHeadersHashCache = _blockHeadersHashCache
+    , blockHeadersCache = _blockHeadersCache
     , blockHeadersDBPool = _blockHeadersDBPool
     , currentTip = _currentTip -- websockets' init data relies on whole BlockHeader
     , logFunc = logFunc

--- a/op-energy-backend/src/OpEnergy/Server/V1/Config.hs
+++ b/op-energy-backend/src/OpEnergy/Server/V1/Config.hs
@@ -57,6 +57,8 @@ data Config = Config
     -- ^ minimum log level to display
   , configPrometheusPort :: Positive Int
     -- ^ port which should be used by prometheus metrics
+  , configCacheChunkSize :: Positive Int
+    -- ^ defines size of chunk with which cache is grown
   }
   deriving Show
 instance FromJSON Config where
@@ -79,6 +81,7 @@ instance FromJSON Config where
     <*> ( v .:? "WEBSOCKET_KEEP_ALIVE_SECS" .!= (configWebsocketKeepAliveSecs defaultConfig))
     <*> ( v .:? "LOG_LEVEL_MIN" .!= (configLogLevelMin defaultConfig))
     <*> ( v .:? "PROMETHEUS_PORT" .!= (configPrometheusPort defaultConfig))
+    <*> ( v .:? "CACHE_CHUNK_SIZE" .!= (configCacheChunkSize defaultConfig))
 
 defaultConfig:: Config
 defaultConfig = Config
@@ -100,6 +103,7 @@ defaultConfig = Config
   , configWebsocketKeepAliveSecs = 10
   , configLogLevelMin = LevelWarn
   , configPrometheusPort = 7999
+  , configCacheChunkSize = 50000
   }
 
 getConfigFromEnvironment :: IO Config

--- a/op-energy-backend/src/OpEnergy/Server/V1/Metrics.hs
+++ b/op-energy-backend/src/OpEnergy/Server/V1/Metrics.hs
@@ -22,25 +22,29 @@ import           Data.OpEnergy.API.V1.Positive
 data MetricsState = MetricsState
   { syncBlockHeadersH :: P.Histogram
   , btcGetBlockchainInfoH :: P.Histogram
+  , btcGetBlockHashH :: P.Histogram
+  , btcGetBlockH :: P.Histogram
+  , btcGetBlockStatsH :: P.Histogram
   , mgetBlockHeaderByHeightH :: P.Histogram
   , mgetBlockHeaderByHashH :: P.Histogram
     -- for mgetBlockHeaderByHeight
-  , mgetBlockHeaderByHeightCacheH :: P.Histogram
-  , mgetBlockHeaderByHeightCacheHit :: P.Counter
-  , mgetBlockHeaderByHeightCacheMiss :: P.Counter
-  , mgetBlockHeaderByHeightCacheInsert :: P.Histogram
-  , mgetBlockHeaderByHeightCacheDBLookup :: P.Histogram
+  , blockHeaderHeightCacheH :: P.Histogram
+  , blockHeaderHeightCacheHit :: P.Counter
+  , blockHeaderHeightCacheMiss :: P.Counter
+  , blockHeaderHeightCacheInsert :: P.Histogram
+  , blockHeaderHeightCacheEnsureCapacity :: P.Histogram
     -- for getBlockHeaderByHash
-  , mgetBlockHeaderByHashCacheH :: P.Histogram
-  , mgetBlockHeaderByHashCacheHit :: P.Counter
-  , mgetBlockHeaderByHashCacheMiss :: P.Counter
-  , mgetBlockHeaderByHashCacheInsert :: P.Histogram
-  , mgetBlockHeaderByHashCacheDBLookup :: P.Histogram
+  , blockHeaderHashCacheH :: P.Histogram
+  , blockHeaderHashCacheHit :: P.Counter
+  , blockHeaderHashCacheMiss :: P.Counter
+  , blockHeaderHashCacheInsert :: P.Histogram
     -- for getBlockSpanList
   , getBlockSpanListH :: P.Histogram
     -- calculateStatistics
   , calculateStatisticsH :: P.Histogram
+    -- insertion into DB table BlockHeader
   , blockHeaderDBInsertH :: P.Histogram
+  , blockHeaderCacheFromDBLookup :: P.Histogram
   }
 
 -- | constructs default state with given config and DB pool
@@ -48,44 +52,50 @@ initMetrics :: MonadIO m => Config-> m MetricsState
 initMetrics _config = do
   syncBlockHeadersH <- P.register $ P.histogram (P.Info "syncBlockHeader" "") P.defaultBuckets
   btcGetBlockchainInfoH <- P.register $ P.histogram (P.Info "btcGetBlockchainInfo" "") P.defaultBuckets
+  btcGetBlockHashH <- P.register $ P.histogram (P.Info "btcGetBlockHashH" "") P.defaultBuckets
+  btcGetBlockH <- P.register $ P.histogram (P.Info "btcGetBlockH" "") P.defaultBuckets
+  btcGetBlockStatsH <- P.register $ P.histogram (P.Info "btcGetBlockStatsH" "") P.defaultBuckets
   -- mgetBlockHeaderByHeight
   mgetBlockHeaderByHeightH <- P.register $ P.histogram (P.Info "mgetBlockHeaderByHeight" "") P.defaultBuckets
-  mgetBlockHeaderByHeightCacheH <- P.register $ P.histogram (P.Info "mgetBlockHeaderByHeightCache" "") P.defaultBuckets
-  mgetBlockHeaderByHeightCacheHit <- P.register $ P.counter (P.Info "mgetBlockHeaderByHeightCacheHit" "")
-  mgetBlockHeaderByHeightCacheMiss <- P.register $ P.counter (P.Info "mgetBlockHeaderByHeightCacheMiss" "")
-  mgetBlockHeaderByHeightCacheInsert <- P.register $ P.histogram (P.Info "mgetBlockHeaderByHeightCacheInsert" "") P.defaultBuckets
-  mgetBlockHeaderByHeightCacheDBLookup <- P.register $ P.histogram (P.Info "mgetBlockHeaderByHeightDBLookup" "") P.defaultBuckets
+  blockHeaderHeightCacheH <- P.register $ P.histogram (P.Info "blockHeaderHeightCache" "") P.defaultBuckets
+  blockHeaderHeightCacheHit <- P.register $ P.counter (P.Info "blockHeaderHeightCacheHit" "")
+  blockHeaderHeightCacheMiss <- P.register $ P.counter (P.Info "blockHeaderHeightCacheMiss" "")
+  blockHeaderHeightCacheInsert <- P.register $ P.histogram (P.Info "blockHeaderHeightCacheInsert" "") P.defaultBuckets
   -- getBlockHeaderByHash
   mgetBlockHeaderByHashH <- P.register $ P.histogram (P.Info "mgetBlockHeaderByHash" "") P.defaultBuckets
-  mgetBlockHeaderByHashCacheH <- P.register $ P.histogram (P.Info "mgetBlockHeaderByHashCache" "") P.defaultBuckets
-  mgetBlockHeaderByHashCacheHit <- P.register $ P.counter (P.Info "mgetBlockHeaderByHashCacheHit" "")
-  mgetBlockHeaderByHashCacheMiss <- P.register $ P.counter (P.Info "mgetBlockHeaderByHashCacheMiss" "")
-  mgetBlockHeaderByHashCacheInsert <- P.register $ P.histogram (P.Info "mgetBlockHeaderByHashCacheInsert" "") P.defaultBuckets
-  mgetBlockHeaderByHashCacheDBLookup <- P.register $ P.histogram (P.Info "mgetBlockHeaderByHashDBLookup" "") P.defaultBuckets
+  blockHeaderHashCacheH <- P.register $ P.histogram (P.Info "blockHeaderHashCache" "") P.defaultBuckets
+  blockHeaderHashCacheHit <- P.register $ P.counter (P.Info "blockHeaderHashCacheHit" "")
+  blockHeaderHashCacheMiss <- P.register $ P.counter (P.Info "blockHeaderHashCacheMiss" "")
+  blockHeaderHashCacheInsert <- P.register $ P.histogram (P.Info "blockHeaderHashCacheInsert" "") P.defaultBuckets
   -- getBockSpanList
   getBlockSpanListH <- P.register $ P.histogram (P.Info "getBlockSpanList" "") P.defaultBuckets
   calculateStatisticsH <- P.register $ P.histogram (P.Info "calculateStatistics" "") P.defaultBuckets
-  blockHeaderDBInsertH <- P.register $ P.histogram (P.Info "blockHeaderDBInsertH" "") P.defaultBuckets
+  blockHeaderDBInsertH <- P.register $ P.histogram (P.Info "blockHeaderDBInsert" "") P.defaultBuckets
+  blockHeaderHeightCacheEnsureCapacity <- P.register $ P.histogram (P.Info "blockHeaderHeightCacheEnsureCapacity" "") P.defaultBuckets
+  blockHeaderCacheFromDBLookup <- P.register $ P.histogram (P.Info "blockHeaderCacheFromDBLookup" "") P.defaultBuckets
   _ <- P.register P.ghcMetrics
   _ <- P.register P.procMetrics
   return $ MetricsState
     { syncBlockHeadersH = syncBlockHeadersH
     , btcGetBlockchainInfoH = btcGetBlockchainInfoH
+    , btcGetBlockHashH = btcGetBlockHashH
+    , btcGetBlockH = btcGetBlockH
+    , btcGetBlockStatsH = btcGetBlockStatsH
     , mgetBlockHeaderByHeightH = mgetBlockHeaderByHeightH
     , mgetBlockHeaderByHashH = mgetBlockHeaderByHashH
-    , mgetBlockHeaderByHeightCacheH = mgetBlockHeaderByHeightCacheH
-    , mgetBlockHeaderByHeightCacheHit = mgetBlockHeaderByHeightCacheHit
-    , mgetBlockHeaderByHeightCacheMiss = mgetBlockHeaderByHeightCacheMiss
-    , mgetBlockHeaderByHeightCacheInsert = mgetBlockHeaderByHeightCacheInsert
-    , mgetBlockHeaderByHeightCacheDBLookup = mgetBlockHeaderByHeightCacheDBLookup
-    , mgetBlockHeaderByHashCacheH = mgetBlockHeaderByHashCacheH
-    , mgetBlockHeaderByHashCacheHit = mgetBlockHeaderByHashCacheHit
-    , mgetBlockHeaderByHashCacheMiss = mgetBlockHeaderByHashCacheMiss
-    , mgetBlockHeaderByHashCacheInsert = mgetBlockHeaderByHashCacheInsert
-    , mgetBlockHeaderByHashCacheDBLookup = mgetBlockHeaderByHashCacheDBLookup
+    , blockHeaderHeightCacheH = blockHeaderHeightCacheH
+    , blockHeaderHeightCacheHit = blockHeaderHeightCacheHit
+    , blockHeaderHeightCacheMiss = blockHeaderHeightCacheMiss
+    , blockHeaderHeightCacheInsert = blockHeaderHeightCacheInsert
+    , blockHeaderHeightCacheEnsureCapacity = blockHeaderHeightCacheEnsureCapacity
+    , blockHeaderHashCacheH = blockHeaderHashCacheH
+    , blockHeaderHashCacheHit = blockHeaderHashCacheHit
+    , blockHeaderHashCacheMiss = blockHeaderHashCacheMiss
+    , blockHeaderHashCacheInsert = blockHeaderHashCacheInsert
     , getBlockSpanListH = getBlockSpanListH
     , calculateStatisticsH = calculateStatisticsH
     , blockHeaderDBInsertH = blockHeaderDBInsertH
+    , blockHeaderCacheFromDBLookup = blockHeaderCacheFromDBLookup
     }
 
 -- | runs metrics HTTP server

--- a/op-energy-backend/src/OpEnergy/Server/V1/Metrics.hs
+++ b/op-energy-backend/src/OpEnergy/Server/V1/Metrics.hs
@@ -21,6 +21,7 @@ import           Data.OpEnergy.API.V1.Positive
 -- | defines the whole state used by backend
 data MetricsState = MetricsState
   { syncBlockHeadersH :: P.Histogram
+  , loadDBStateH :: P.Histogram
   , btcGetBlockchainInfoH :: P.Histogram
   , btcGetBlockHashH :: P.Histogram
   , btcGetBlockH :: P.Histogram
@@ -45,6 +46,7 @@ data MetricsState = MetricsState
     -- insertion into DB table BlockHeader
   , blockHeaderDBInsertH :: P.Histogram
   , blockHeaderCacheFromDBLookup :: P.Histogram
+  , getBlocksByBlockSpan :: P.Histogram
   , getBlocksWithNbdrByBlockSpan :: P.Histogram
   }
 
@@ -52,6 +54,7 @@ data MetricsState = MetricsState
 initMetrics :: MonadIO m => Config-> m MetricsState
 initMetrics _config = do
   syncBlockHeadersH <- P.register $ P.histogram (P.Info "syncBlockHeader" "") microBuckets
+  loadDBStateH <- P.register $ P.histogram (P.Info "loadDBState" "") microBuckets
   btcGetBlockchainInfoH <- P.register $ P.histogram (P.Info "btcGetBlockchainInfo" "") microBuckets
   btcGetBlockHashH <- P.register $ P.histogram (P.Info "btcGetBlockHashH" "") microBuckets
   btcGetBlockH <- P.register $ P.histogram (P.Info "btcGetBlockH" "") microBuckets
@@ -74,11 +77,13 @@ initMetrics _config = do
   blockHeaderDBInsertH <- P.register $ P.histogram (P.Info "blockHeaderDBInsert" "") microBuckets
   blockHeaderHeightCacheEnsureCapacity <- P.register $ P.histogram (P.Info "blockHeaderHeightCacheEnsureCapacity" "") microBuckets
   blockHeaderCacheFromDBLookup <- P.register $ P.histogram (P.Info "blockHeaderCacheFromDBLookup" "") microBuckets
+  getBlocksByBlockSpan <- P.register $ P.histogram (P.Info "getBlocksByBlockSpan" "") microBuckets
   getBlocksWithNbdrByBlockSpan <- P.register $ P.histogram (P.Info "getBlocksWithNbdrByBlockSpan" "") microBuckets
   _ <- P.register P.ghcMetrics
   _ <- P.register P.procMetrics
   return $ MetricsState
     { syncBlockHeadersH = syncBlockHeadersH
+    , loadDBStateH = loadDBStateH
     , btcGetBlockchainInfoH = btcGetBlockchainInfoH
     , btcGetBlockHashH = btcGetBlockHashH
     , btcGetBlockH = btcGetBlockH
@@ -98,6 +103,7 @@ initMetrics _config = do
     , calculateStatisticsH = calculateStatisticsH
     , blockHeaderDBInsertH = blockHeaderDBInsertH
     , blockHeaderCacheFromDBLookup = blockHeaderCacheFromDBLookup
+    , getBlocksByBlockSpan = getBlocksByBlockSpan
     , getBlocksWithNbdrByBlockSpan = getBlocksWithNbdrByBlockSpan
     }
   where


### PR DESCRIPTION
This PR:
features:
1. introduces API calls:
- /api/v1/oe/blockbyblockspan, which returns list of start and end block headers per blockspan. This call is useful for blockspans-home frontend component;
- /api/v1/oe/blockswithnbdrbyblockspan, which returns of start and end block headers of each blockspan as well as it's NBDR value;
2. replaces blockspans-home component's calls to backend with /api/v1/oe/blockbyblockspan in order to use 1 API call instead of 2 * blockspan count API calls;
3. introduces frontend's API calls: opEnergyApiService.$getBlocksByBlockSpan and opEnergyApiService.$getBlocksWithNbdrByBlockSpan;
4. introduces `CACHE_CHUNK_SIZE` config option with default value of 50000

fixes:
- in order to satisfy the requirement to keep all the block headers in the cache, cache had been refactored to provide O(1) asymptotic complexity by using mutable vector of immutable and mutable vectors of size `CACHE_CHUNK_SIZE` in order to provide a way to keep most part of cache immutable and in the out-of-garbage-collector-area. And the only mutable part is the top `tip % configCacheChunkSize` elements which will become immutable as soon as such vector will be filled...
- replaced Text with ShortByteString for Hash datatype in order to reduce RAM space usage;
- few metrics fixes